### PR TITLE
refactor: no need for initial OLAS mint

### DIFF
--- a/contracts/OLAS.sol
+++ b/contracts/OLAS.sol
@@ -32,13 +32,10 @@ contract OLAS is ERC20 {
     // Minter address
     address public minter;
 
-    constructor(uint256 _supply) ERC20("Autonolas", "OLAS", 18) {
+    constructor() ERC20("Autonolas", "OLAS", 18) {
         owner = msg.sender;
         minter = msg.sender;
         timeLaunch = block.timestamp;
-        if (_supply > 0) {
-            _mint(msg.sender, _supply);
-        }
     }
 
     /// @dev Changes the owner address.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,7 @@
 Pre-deploy steps:
 1. Release version of all contracts in `autonolas-governance` with final bytecode.
 2. Create and test contract deployFabric with `create2()` and `changeOwner()`, `changeMinter()`.
+3. Test the deployment with closest to real environment.
 
 The steps of deploying the contracts in this repository are as follows:
 

--- a/test/GovernanceOLAS.js
+++ b/test/GovernanceOLAS.js
@@ -34,7 +34,7 @@ describe("Governance OLAS", function () {
         await gnosisSafeProxyFactory.deployed();
 
         const Token = await ethers.getContractFactory("OLAS");
-        token = await Token.deploy(0);
+        token = await Token.deploy();
         await token.deployed();
 
         // Dispenser address is irrelevant in these tests, so its contract is passed as a zero address

--- a/test/OLAS.js
+++ b/test/OLAS.js
@@ -23,7 +23,8 @@ describe("OLAS", function () {
         [deployer, treasury, bob, alice] = await ethers.getSigners();
         olaFactory = await ethers.getContractFactory("OLAS");
         // Treasury address is deployer by default
-        olas = await olaFactory.deploy(initSupply);
+        olas = await olaFactory.deploy();
+        await olas.mint(deployer.address, initSupply);
         // Changing the treasury address
         await olas.connect(deployer).changeMinter(treasury.address);
     });

--- a/test/Sale.js
+++ b/test/Sale.js
@@ -20,7 +20,7 @@ describe("Sale contract", function () {
 
     beforeEach(async function () {
         const OLAS = await ethers.getContractFactory("OLAS");
-        olas = await OLAS.deploy(0);
+        olas = await OLAS.deploy();
         await olas.deployed();
 
         signers = await ethers.getSigners();

--- a/test/buOLAS.js
+++ b/test/buOLAS.js
@@ -16,7 +16,7 @@ describe("buOLAS", function () {
 
     beforeEach(async function () {
         const OLAS = await ethers.getContractFactory("OLAS");
-        olas = await OLAS.deploy(0);
+        olas = await OLAS.deploy();
         await olas.deployed();
 
         signers = await ethers.getSigners();

--- a/test/veOLAS.js
+++ b/test/veOLAS.js
@@ -17,7 +17,7 @@ describe("Voting Escrow OLAS", function () {
 
     beforeEach(async function () {
         const OLAS = await ethers.getContractFactory("OLAS");
-        olas = await OLAS.deploy(0);
+        olas = await OLAS.deploy();
         await olas.deployed();
 
         signers = await ethers.getSigners();

--- a/test/xbuOLAS.js
+++ b/test/xbuOLAS.js
@@ -13,7 +13,7 @@ describe("Time shifting buOLAS", function () {
 
     beforeEach(async function () {
         const OLAS = await ethers.getContractFactory("OLAS");
-        olas = await OLAS.deploy(0);
+        olas = await OLAS.deploy();
         await olas.deployed();
 
         signers = await ethers.getSigners();


### PR DESCRIPTION
- Getting rid of initial supply in the OLAS mint;
- Adding one more line in the pre-deployment description.