### PR TITLE
doc: convert vulnerabilities PDF to markdown and use relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,57 +8,57 @@ This repository contains the Autonolas `OLAS` token and the governance part of t
 
 A graphical overview of the whole on-chain architecture is available here:
 
-A graphical overview is available [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/flowchart.md).
+A graphical overview is available [here](docs/flowchart.md).
 
-For reference purposes only, an older version of the general Autonolas architecture is available [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/On-chain_architecture_v5.png).
+For reference purposes only, an older version of the general Autonolas architecture is available [here](docs/On-chain_architecture_v5.png).
 
 We follow the standard governance setup by OpenZeppelin. Our governance token is a voting escrow token (`veOLAS`) created by locking `OLAS`.
 
-An overview of the design is provided [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Governance_process.pdf) and the contracts' specifications are provided [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Specs%20of%20governance%20contracts_v1.1.0.pdf).
+An overview of the design is provided [here](docs/Governance_process.pdf) and the contracts' specifications are provided [here](docs/Specs%20of%20governance%20contracts_v1.1.0.pdf).
 
-- [OLAS](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/OLAS.sol);
-- [VotingEscrow (veOLAS)](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/veOLAS.sol);
-- [GovernorOLAS](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/GovernorOLAS.sol);
-- [Timelock](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/Timelock.sol).
+- [OLAS](contracts/OLAS.sol);
+- [VotingEscrow (veOLAS)](contracts/veOLAS.sol);
+- [GovernorOLAS](contracts/GovernorOLAS.sol);
+- [Timelock](contracts/Timelock.sol).
 
 For team incentivisation we have a burnable locked `OLAS` token - `buOLAS`:
-- [buOLAS (deprecated)](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/buOLAS.sol).
+- [buOLAS (deprecated)](contracts/buOLAS.sol).
 
 In order to deploy OLAS and veOLAS contracts via the create2() method, the following contract is utilized for vanity addresses:
-- [DeploymentFactory](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/DeploymentFactory.sol).
+- [DeploymentFactory](contracts/DeploymentFactory.sol).
 
 To address several found `veOLAS` contract view functions issues, a wrapper contract `wveOLAS` is implemented:
-- [wveOLAS (veOLAS wrapper)](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/wveOLAS.sol).
+- [wveOLAS (veOLAS wrapper)](contracts/wveOLAS.sol).
 
-The changelog leading to the implementation of `wveOLAS` can be found here: [Changelog_v1.1.0](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Changelog_v1.1.0.pdf)
+The changelog leading to the implementation of `wveOLAS` can be found here: [Changelog_v1.1.0](docs/Changelog_v1.1.0.pdf)
 
-To complement, a list of known vulnerabilities can be found here: [Vulnerabilities list](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Vulnerabilities_list_governance.pdf)
+To complement, a list of known vulnerabilities can be found here: [Vulnerabilities list](docs/Vulnerabilities_list_governance.md)
 
 In order to manage cross-bridge transactions via the `Timelock` contract on L2 networks, the following contracts are implemented:
-- Polygon PoS: [FxGovernorTunnel](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/bridges/FxGovernorTunnel.sol);
-- Gnosis: [HomeMediator](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/bridges/HomeMediator.sol);
-- Optimism and Base: [OptimismMessenger](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/bridges/OptimismMessenger.sol);
-- L2 networks without own native bridge: [WormholeMessenger](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/bridges/WormholeMessenger.sol);
+- Polygon PoS: [FxGovernorTunnel](contracts/bridges/FxGovernorTunnel.sol);
+- Gnosis: [HomeMediator](contracts/bridges/HomeMediator.sol);
+- Optimism and Base: [OptimismMessenger](contracts/bridges/OptimismMessenger.sol);
+- L2 networks without own native bridge: [WormholeMessenger](contracts/bridges/WormholeMessenger.sol);
 
-The functionality thereby enabled is outlined in detail here: [Cross-chain governance](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/governace_bridge.pdf).
+The functionality thereby enabled is outlined in detail here: [Cross-chain governance](docs/governace_bridge.pdf).
 
 Exceptionally, some changes to the Autonolas Protocol can be executed by a community-owned multisig wallet (CM), bypassing the governance process (see [here](https://github.com/valory-xyz/autonolas-aip/blob/aip-3/content/aips/core-enhancing-autonolas-protocol-security.md)). To align CM actions with the DAO’s intent and ensure their reversibility, the following contracts are implemented:
-- [GuardCM](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/GuardCM.sol)
-- [VerifyData](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/VerifyData.sol)
-- [ProcessBridgedDataArbitrum](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/ProcessBridgedDataArbitrum.sol)
-- [ProcessBridgedDataGnosis](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/ProcessBridgedDataGnosis.sol)
-- [ProcessBridgedDataOptimism](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/ProcessBridgedDataOptimism.sol)
-- [ProcessBridgedDataPolygon](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/ProcessBridgedDataPolygon.sol)
-- [ProcessBridgedDataWormhole](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/ProcessBridgedDataWormhole.sol)
-- [VerifyBridgedData](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/multisigs/bridge_verifier/VerifyBridgedData.sol)
+- [GuardCM](contracts/multisigs/GuardCM.sol)
+- [VerifyData](contracts/multisigs/VerifyData.sol)
+- [ProcessBridgedDataArbitrum](contracts/multisigs/bridge_verifier/ProcessBridgedDataArbitrum.sol)
+- [ProcessBridgedDataGnosis](contracts/multisigs/bridge_verifier/ProcessBridgedDataGnosis.sol)
+- [ProcessBridgedDataOptimism](contracts/multisigs/bridge_verifier/ProcessBridgedDataOptimism.sol)
+- [ProcessBridgedDataPolygon](contracts/multisigs/bridge_verifier/ProcessBridgedDataPolygon.sol)
+- [ProcessBridgedDataWormhole](contracts/multisigs/bridge_verifier/ProcessBridgedDataWormhole.sol)
+- [VerifyBridgedData](contracts/multisigs/bridge_verifier/VerifyBridgedData.sol)
 
-The functionality enabled by this modular guard mechanism is introduced [here](https://github.com/valory-xyz/autonolas-governance/blob/main/governance/docs/guardCM_modular_approach.pdf).
+The functionality enabled by this modular guard mechanism is introduced [here](governance/docs/guardCM_modular_approach.pdf).
 
 The following contract was implemented to allow DAO members (via veOLAS) to vote on staking programs and trigger Olas Staking emissions, assigning weights according to their preferences"
-- [VoteWeighting.sol](https://github.com/valory-xyz/autonolas-governance/blob/main/contracts/VoteWeighting.sol).
+- [VoteWeighting.sol](contracts/VoteWeighting.sol).
 
 This contracts adopts a model similar to the [Curve Gauge Controller](https://curve.readthedocs.io/dao-gauges.html#dao-gauges-controller), maintains a list of gauges and their associated weights.  Modifications from the original Curve Gauge Controller include granting anyone the ability to add staking contracts by removing ownership control on this functionality, and eliminating additional categorization by contract type. 
-For more details on VotingWeight, see [Olas staking smart contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/StakingSmartContracts.pdf) and [Olas staking whitepaper](https://staking.olas.network/poaa-whitepaper.pdf).
+For more details on VotingWeight, see [Olas staking smart contracts](docs/StakingSmartContracts.pdf) and [Olas staking whitepaper](https://staking.olas.network/poaa-whitepaper.pdf).
 
 ## Development
 
@@ -135,33 +135,33 @@ several steps in order to be verified. Those include:
 
 ### Comparison of veOLAS and Curve Voting Escrow (veCRV) contracts via forking
 Several test scripts have been written in order to compare the behavior of veOLAS and veCRV, which can be found here:
-[veCompare](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/veCompare).
+[veCompare](scripts/veCompare).
 
-The original Voting Escrow ABI is located here: [veCRV ABI](https://github.com/valory-xyz/autonolas-governance/blob/main/abis/test/veCRV.json).
+The original Voting Escrow ABI is located here: [veCRV ABI](abis/test/veCRV.json).
 One can run the forking test via the `npm run fork` command as described above.
 
 ## Deployment of Core Contracts
 The deployment of contracts to the test- and main-net is split into step-by-step series of scripts for more control and checkpoint convenience.
-The description of deployment procedure can be found here: [deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+The description of deployment procedure can be found here: [deployment](scripts/deployment).
 
 The finalized contract ABIs for deployment and their number of optimization passes are located here:
-[ABIs](https://github.com/valory-xyz/autonolas-governance/blob/main/abis).
+[ABIs](abis).
 
 ## Bridges
 
 ### Cross-chain governance
 Depending on the network, the cross-chain functionalities enabled are outlined in detail here:
-[Cross-chain governance](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/governace_bridge.pdf).
+[Cross-chain governance](docs/governace_bridge.pdf).
 
 In order to correctly pack the data and supply it to the Timelock such that it is correctly processed across the bridge,
-use the following script: [cross-bridge data packing](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/pack_data.js).
+use the following script: [cross-bridge data packing](scripts/deployment/bridges/pack_data.js).
 
 #### Polygon governance bridge 
 Autonolas will use the [FxPortal](https://github.com/fx-portal/contracts) developed and designed by the Polygon team to support cross-chain bridging from Ethereum to Polygon.
 
 For running a test between `goerli` and `mumbai`, run the test script with your own credentials:
-[`goerli-mumbai` hello world bridge test](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/polygon/test/fx_goerli_mumbai_hello_world.js)
-and [`goerli-mumbai` governor bridge test](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/polygon/test/fx_goerli_mumbai_governor.js).
+[`goerli-mumbai` hello world bridge test](scripts/deployment/bridges/polygon/test/fx_goerli_mumbai_hello_world.js)
+and [`goerli-mumbai` governor bridge test](scripts/deployment/bridges/polygon/test/fx_goerli_mumbai_governor.js).
 Note that the script must be run without Hardhat environment, i.e.: `node test_script.js`.
 
 #### Gnosis governance bridge
@@ -169,8 +169,8 @@ Autonolas will use the [Arbitrary Message Bridge](https://docs.gnosischain.com/b
 and designed by the Gnosis team to support cross-chain bridging from Ethereum to Gnosis Chain.
 
 For running a test between `goerli` and `chiado`, run the test script with your own credentials:
-[`goerli-chiado` hello world bridge test](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/gnosis/test/mediator_goerli_chiado_hello_world.js)
-and [`goerli-chiado` governor bridge test](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/polygon/test/mediator_goerli_chiado_governor.js).
+[`goerli-chiado` hello world bridge test](scripts/deployment/bridges/gnosis/test/mediator_goerli_chiado_hello_world.js)
+and [`goerli-chiado` governor bridge test](scripts/deployment/bridges/polygon/test/mediator_goerli_chiado_governor.js).
 Note that the script must be run without Hardhat environment, i.e.: `node test_script.js`.
 
 #### Arbitrum governance bridge
@@ -197,36 +197,36 @@ Note that the script must be run without Hardhat environment, i.e.: `node test_s
 
 ### Deployment of bridge-related contracts
 The description of bridge-related deployment procedure is very similar to the original deployment process and can be found here:
-- [bridges-polygon](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/polygon);
-- [bridges-gnosis](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/gnosis);
-- [bridges-optimism-base](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/optimistic);
-- [bridges-wormhole](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/wormhole).
+- [bridges-polygon](scripts/deployment/bridges/polygon);
+- [bridges-gnosis](scripts/deployment/bridges/gnosis);
+- [bridges-optimism-base](scripts/deployment/bridges/optimistic);
+- [bridges-wormhole](scripts/deployment/bridges/wormhole).
 
 ### ERC20 token bridging
 Autonolas will use native bridges for ERC20 token transfers, where possible. If a native bridge is not available or
 does not correspond to all the required specifications, the [Wormhole Portal](https://portalbridge.com/advanced-tools/#/transfer)
 is utilized in order to manage the ERC20 token transfers between L1 and L2-s.
 
-For more information about OLAS bridging see [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/olas_bridging.md)  
+For more information about OLAS bridging see [here](docs/olas_bridging.md)  
 
 #### Special case (currently not utilized): ERC20 token bridging between Polygon and Ethereum
 The contract design facilitating token bridging between the Polygon and Ethereum networks, along with the underlying
 motivations driving the creation of these contracts, is outlined here:
-[Bridging token](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Bonding_mechanism_with_Polygon_LP_token.pdf).
+[Bridging token](docs/Bonding_mechanism_with_Polygon_LP_token.pdf).
 
 The description of ERC20 token bridging deployment between Polygon and Ethereum can be found here:
-[deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+[deployment](scripts/deployment).
 
 ## Documents
-All the project-related documents are located here: [docs](https://github.com/valory-xyz/autonolas-governance/blob/main/docs).
+All the project-related documents are located here: [docs](docs).
 
 ### Code optimizations and best practices
 The list of optimization considerations and best practices exercised during the development of Autonolas governance
-can be found [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/optimizations.md).
+can be found [here](docs/optimizations.md).
 
 ### Audits
-- The audit is provided as development matures. The latest audit report can be found here: [audits](https://github.com/valory-xyz/autonolas-governance/blob/main/audits).
-- The list of known vulnerabilities can be found here: [Vulnerabilities list](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/Vulnerabilities_list_governance.pdf).
+- The audit is provided as development matures. The latest audit report can be found here: [audits](audits).
+- The list of known vulnerabilities can be found here: [Vulnerabilities list](docs/Vulnerabilities_list_governance.md).
 
 #### Static audit
 The static audit checks all the deployed contracts on-chain info correctness and can be run using the following script:
@@ -235,7 +235,7 @@ node scripts/audit_chains/audit_contracts_setup.js
 ```
 
 ### Deployed Protocol
-The list of contract addresses for different chains and their full contract configuration can be found [here](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/configuration.json).
+The list of contract addresses for different chains and their full contract configuration can be found [here](docs/configuration.json).
 
 In order to test the protocol setup on all the deployed chains, the audit script is implemented. Make sure to export
 required API keys for corresponding chains (see the script for more information). The audit script can be run as follows:

--- a/audits/README.md
+++ b/audits/README.md
@@ -2,51 +2,51 @@
 This folder contains audit-related materials.
 
 ### Token
-Records of audit related materials of contracts the Autonolas token is based on can be found here: [token audit](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/token).
+Records of audit related materials of contracts the Autonolas token is based on can be found here: [token audit](audits/token).
 
 ### Internal audit
-The latest internal audit is located in this folder: [internal audit](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal).
+The latest internal audit is located in this folder: [internal audit](audits/internal).
 
-An internal audit with a focus on `wveOLAS` contract is located in this folder: [internal audit 2](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal2).
+An internal audit with a focus on `wveOLAS` contract is located in this folder: [internal audit 2](audits/internal2).
 
-An internal audit with a focus on `FxGovernorTunnel` contract is located in this folder: [internal audit 3](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal3).
+An internal audit with a focus on `FxGovernorTunnel` contract is located in this folder: [internal audit 3](audits/internal3).
 
-An internal audit with a focus on `HomeMediator` contract is located in this folder: [internal audit 4](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal4).
+An internal audit with a focus on `HomeMediator` contract is located in this folder: [internal audit 4](audits/internal4).
 
-An internal audit with a focus on `GovernorOLAS update to latest OZ version` is located in this folder: [internal audit 5](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal5).
+An internal audit with a focus on `GovernorOLAS update to latest OZ version` is located in this folder: [internal audit 5](audits/internal5).
 
-An internal audit with a focus on `Guard for Community Multisig (CM)` is located in this folder: [internal audit 6](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal6).
+An internal audit with a focus on `Guard for Community Multisig (CM)` is located in this folder: [internal audit 6](audits/internal6).
 
-An internal audit with a focus on `ERC20 bridging via fx-tunnel` is located in this folder: [internal audit 7](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal7).
+An internal audit with a focus on `ERC20 bridging via fx-tunnel` is located in this folder: [internal audit 7](audits/internal7).
 
-An internal audit with a focus on `Update for Community Multisig (CM)` is located in this folder: [internal audit 8](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal8).
+An internal audit with a focus on `Update for Community Multisig (CM)` is located in this folder: [internal audit 8](audits/internal8).
 
-An internal audit with a focus on `OptimismMesseger and WormholeMessenger` is located in this folder: [internal audit 9](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal9).
+An internal audit with a focus on `OptimismMesseger and WormholeMessenger` is located in this folder: [internal audit 9](audits/internal9).
 
-An internal audit with a focus on `Guard for Community Multisig (CM) (modular version)` is located in this folder: [internal audit 10](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal10).
+An internal audit with a focus on `Guard for Community Multisig (CM) (modular version)` is located in this folder: [internal audit 10](audits/internal10).
 
-An internal audit with a focus on `VoteWeighting` is located in this folder: [internal audit 12](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12).
+An internal audit with a focus on `VoteWeighting` is located in this folder: [internal audit 12](audits/internal12).
 
-An internal audit with a focus on `VoteWeighting` (after C4A external audit) is located in this folder: [internal audit 13](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal13).
+An internal audit with a focus on `VoteWeighting` (after C4A external audit) is located in this folder: [internal audit 13](audits/internal13).
 
-An internal audit with a focus on `WormholeRelayerTimelock` is located in this folder: [internal audit 14](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal14).
+An internal audit with a focus on `WormholeRelayerTimelock` is located in this folder: [internal audit 14](audits/internal14).
 
-An internal audit with a focus on `GovernorOLAS` is located in this folder: [internal audit 15](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal15).
+An internal audit with a focus on `GovernorOLAS` is located in this folder: [internal audit 15](audits/internal15).
 
-An internal audit with a focus on `WormholeRelayerTimelock` is located in this folder: [internal audit 16](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal16).
+An internal audit with a focus on `WormholeRelayerTimelock` is located in this folder: [internal audit 16](audits/internal16).
 
-An internal audit with a focus on `GuardCM` is located in this folder: [internal audit 17](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal17).
+An internal audit with a focus on `GuardCM` is located in this folder: [internal audit 17](audits/internal17).
 
-An internal audit with a focus on post-external-audit is located in this folder: [internal audit 18](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal18).
+An internal audit with a focus on post-external-audit is located in this folder: [internal audit 18](audits/internal18).
 
 ### External audit
-Following the initial contracts [audit report](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/Valory%20Review%20Final.pdf),
-the recommendations are addressed here: [feedback](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/Addressing%20Initial%20ApeWorX%20Recommentations.pdf).
+Following the initial contracts [audit report](audits/Valory%20Review%20Final.pdf),
+the recommendations are addressed here: [feedback](audits/Addressing%20Initial%20ApeWorX%20Recommentations.pdf).
 
 Final audit reports are listed in their historical order:
-- [v1](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v0.1.0.pre-audit.pdf);
-- [v2](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v1.0.0.pdf);
-- [v3](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v1.1.0.pdf);
+- [v1](audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v0.1.0.pre-audit.pdf);
+- [v2](audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v1.0.0.pdf);
+- [v3](audits/Valory%20Smart%20Contract%20Audit%20by%20Solidity%20Finance-v1.1.0.pdf);
 - [v4](https://sourcehat.com/audits/ValoryOLAS/);
 - [v5](https://code4rena.com/reports/2023-12-autonolas);
 - [v6](https://code4rena.com/reports/2024-05-olas).

--- a/audits/internal/README.md
+++ b/audits/internal/README.md
@@ -9,7 +9,7 @@ Update: 09-06-2022  <br>
 The audit focused primarily on `tokens` and `governance` contracts.
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal/analysis/contracts)
 
 ### ERC20 checks
 ```
@@ -148,28 +148,28 @@ slither-check-erc buOLAS-flatten.sol buOLAS
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here (archive):
-[pre_audit_coverage](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/coverage_pre_audit.tar.gz).
+[pre_audit_coverage](audits/internal/analysis/coverage_pre_audit.tar.gz).
 
 After addressing all the issues mentioned below, the coverage has been re-run, and the results are available here (archive):
-[post_audit_coverage](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/coverage_post_audit.tar.gz).
+[post_audit_coverage](audits/internal/analysis/coverage_post_audit.tar.gz).
 
 One can take a look at the image representing the final coverage stage:
-[coverage_image](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/coverage.png).
+[coverage_image](audits/internal/analysis/coverage.png).
 
 Note that the remaining branches are not covered in the `veOLAS` contract since those conditions are unreachable in real meaningful numbers, that has been verified
 by the `echidna` fuzzer (discussed in detail below):
-[example_branches_1](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/fuzzing/VotingEscrow/VotingEscrowVerySimple.sol#L170-L184);
-[example_branches_2](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/fuzzing/VotingEscrow/VotingEscrowFuzzing.sol#L584-L593).
+[example_branches_1](audits/internal/analysis/fuzzing/VotingEscrow/VotingEscrowVerySimple.sol#L170-L184);
+[example_branches_2](audits/internal/analysis/fuzzing/VotingEscrow/VotingEscrowFuzzing.sol#L584-L593).
 
 ### Fuzzing re-check
-The full set of `echidna` fuzzer performance can be found here: [fuzzing](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/fuzzing).
+The full set of `echidna` fuzzer performance can be found here: [fuzzing](audits/internal/analysis/fuzzing).
 
 ### Security issues
 
 Some of the checks are obtained automatically. They are commented and I do not see any serious problems.
 
 All automatic warnings are listed in the following file, concerns of which we address in more detail below:
-[slither-full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/slither_full.txt)
+[slither-full](audits/internal/analysis/slither_full.txt)
 
 ### Addressing issues from the initial report. Updated on the 09-06-2022
 
@@ -185,7 +185,7 @@ Missing tests for OLAS token:
 Missing tests for veOLAS:
 - supportsInterface [x] (fixed)
 - if (amount > type(uint96).max) [x] (fixed)
-- Pay attention to the result of fuzzing: [pre audit fuzzing](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal/analysis/fuzzing/VotingEscrow). Specifically:
+- Pay attention to the result of fuzzing: [pre audit fuzzing](audits/internal/analysis/fuzzing/VotingEscrow). Specifically:
   - Pay attention to getPastVotes(0,0) [x] (fixed by additional testing).
 It can be taken into account that there is a contract deploy/start time for OLAS: timeLaunch.
 veOLAS should not allow tx to be made earlier than this time.

--- a/audits/internal10/README.md
+++ b/audits/internal10/README.md
@@ -9,7 +9,7 @@ Update: 06-03-2024  <br>
 The audit focused on Guard contract for community mutisig (modular version). <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal10/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal10/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -38,10 +38,10 @@ Using sol2uml tools: https://github.com/naddison36/sol2uml <br>
 sol2uml storage . -f png -c GuardCM -o .
 Generated png file GuardCM.png
 ```
-Storage: [GuardCM](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal10/analysis/GuardCM.png)
+Storage: [GuardCM](audits/internal10/analysis/GuardCM.png)
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal10/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal10/analysis/slither_full.txt) <br>
 All is false positive, discussed https://github.com/pessimistic-io/slitherin/blob/master/docs/arbitrary_call.md
 
 Minor issue: <br>

--- a/audits/internal12/README.md
+++ b/audits/internal12/README.md
@@ -9,7 +9,7 @@ Update: 13-05-2024  <br>
 The audit focused on VoteWeighting. <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal12/analysis/contracts)
 
 
 ### Coverage
@@ -37,12 +37,12 @@ cd ../../../../../../
 # Run 
 ./start_echidna.sh
 ```
-result overflow: [fuzzing-overflow.PNG](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis/fuzzing/overflow/fuzzing-overflow.PNG) <br>
-result assert: [fuzzing-assert.PNG](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis/fuzzing/overflow/fuzzing-assert.PNG)
+result overflow: [fuzzing-overflow.PNG](audits/internal12/analysis/fuzzing/overflow/fuzzing-overflow.PNG) <br>
+result assert: [fuzzing-assert.PNG](audits/internal12/analysis/fuzzing/overflow/fuzzing-assert.PNG)
 
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal12/analysis/slither_full.txt) <br>
 
 #### Issue
 Bug in viper->solidity conversion.
@@ -174,7 +174,7 @@ The review has been performed based on the contract code in the following reposi
 commit: `9df1f95ec7e51eacb985aece56654b8d2506e29f` or `tag: v1.2.1-pre-internal-audit` <br> 
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis2/contracts)
+Flatten version of contracts. [contracts](audits/internal12/analysis2/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -183,7 +183,7 @@ VoteWeighting.sol                   |      100 |    96.67 |      100 |    98.64 
 ```
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal12/analysis2/slither_full.txt) <br>
+Details in [slither_full](audits/internal12/analysis2/slither_full.txt) <br>
 all false positive cases.
 
 ### Issue

--- a/audits/internal14/README.md
+++ b/audits/internal14/README.md
@@ -9,7 +9,7 @@ Update: 12-06-2025  <br>
 The audit focused on WormholeRelayerTimelock. <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal14/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal14/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -21,7 +21,7 @@ Please, pay attention and add tests.
 
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal14/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal14/analysis/slither_full.txt) <br>
 All is false positive.
 
 Notes: <br>

--- a/audits/internal18/AUDIT-SUMMARY.md
+++ b/audits/internal18/AUDIT-SUMMARY.md
@@ -67,12 +67,12 @@ No tests exist for the 66-LOC Burner contract.
 - Phase 3: Manual review of all 27 contracts
 - Phase 3.5: Full EVM checklist (134 items), DeFi attack patterns (140 items), access control + token patterns
 - Phase 3b: Deep dives — removeNominee slope lifecycle, FxPortal deployment scripts, bridge parameter matrix
-- Phase 3c: Cross-reference with `docs/Vulnerabilities_list_governance.pdf` (10 known issues)
+- Phase 3c: Cross-reference with `docs/Vulnerabilities_list_governance.md` (10 known issues)
 - Phase 4: Checklist compliance report
 
 ## Cross-reference with Known Vulnerabilities
 
-All 10 items from `docs/Vulnerabilities_list_governance.pdf` confirmed. Our removeNominee finding (Low) extends PDF #8 which only mentions orphaned voting power — the slope drift and potential DoS path at line 611 are NEW, though practical exploitation requires rare conditions.
+All 10 items from `docs/Vulnerabilities_list_governance.md` confirmed. Our removeNominee finding (Low) extends PDF #8 which only mentions orphaned voting power — the slope drift and potential DoS path at line 611 are NEW, though practical exploitation requires rare conditions.
 
 ## Key Defensive Properties Verified
 

--- a/audits/internal18/README.md
+++ b/audits/internal18/README.md
@@ -135,7 +135,7 @@ No actionable Slither findings.
 
 ## Cross-reference with known vulnerabilities
 
-The project maintains `docs/Vulnerabilities_list_governance.pdf` with 10 known issues.
+The project maintains `docs/Vulnerabilities_list_governance.md` with 10 known issues.
 Cross-reference with our findings:
 
 | # | PDF Vulnerability | Severity | Status | Our Assessment |
@@ -495,7 +495,7 @@ autonolas-internal-audit-methodology rules.
 - **Admin roles**: owner (Timelock) = HIGH, multisig (GuardCM) = MEDIUM (pause only if governance dead)
 - **Upgradeability**: None — all contracts deployed directly (no proxy/UUPS/transparent)
 - **Token model**: OLAS (solmate ERC20, standard), veOLAS/buOLAS (non-transferable)
-- **Known issues**: 10 documented in `docs/Vulnerabilities_list_governance.pdf` — all cross-referenced
+- **Known issues**: 10 documented in `docs/Vulnerabilities_list_governance.md` — all cross-referenced
 
 ### Phase 2: Automated Analysis
 - [x] Slither: 242 results, all triaged (see `analysis/slither_full.txt`)
@@ -578,4 +578,4 @@ The following contracts were reviewed in full with no security issues found:
 
 The autonolas-governance codebase is mature and well-audited (17 prior internal audits + C4A external audit). The Curve-derived contracts (veOLAS, VoteWeighting) follow established patterns. The bridge verification system is comprehensive, and the C4A findings have been correctly addressed.
 
-The main finding is the removeNominee slope drift issue (Low), which extends known vulnerability #8 from the project's Vulnerabilities_list_governance.pdf — the PDF documents orphaned voting power but does NOT cover the slope/changesSum drift or the potential DoS path at line 611. The bug is real (raw subtraction should be `_maxAndSub`), but the practical DoS scenario requires a rare confluence of conditions: governance-initiated removal + passive voters + multi-year timeframe. All 10 known vulnerabilities from the PDF were cross-referenced and confirmed.
+The main finding is the removeNominee slope drift issue (Low), which extends known vulnerability #8 from the project's Vulnerabilities_list_governance.md — the document covers orphaned voting power but does NOT cover the slope/changesSum drift or the potential DoS path at line 611. The bug is real (raw subtraction should be `_maxAndSub`), but the practical DoS scenario requires a rare confluence of conditions: governance-initiated removal + passive voters + multi-year timeframe. All 10 known vulnerabilities were cross-referenced and confirmed.

--- a/audits/internal2/README.md
+++ b/audits/internal2/README.md
@@ -9,7 +9,7 @@ Update: 09-03-2023  <br>
 The audit focused on `wveOLAS` contract.
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal2/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal2/analysis/contracts)
 
 ### ERC20 checks
 ```
@@ -115,7 +115,7 @@ Not implemented in wveOLAS, although logically they should be
 Some of the checks are obtained automatically. They are commented and I do not see any serious problems.
 
 All automatic warnings are listed in the following file, concerns of which we address in more detail below:
-[slither-full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal2/analysis/slither_full.txt)
+[slither-full](audits/internal2/analysis/slither_full.txt)
 
 ### Needed Improvements and Bugs fixning
 No major bugs, but some fixes needed

--- a/audits/internal3/README.md
+++ b/audits/internal3/README.md
@@ -9,7 +9,7 @@ Update: 12-04-2023  <br>
 The audit focused on `FxGovernorTunnel` contract.
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal3/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal3/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -25,7 +25,7 @@ File                    |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered L
 Some of the checks are obtained automatically. They are commented and I do not see any serious problems.
 
 All automatic warnings are listed in the following file, concerns of which we address in more detail below:
-[slither-full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal3/analysis/slither_full.txt)
+[slither-full](audits/internal3/analysis/slither_full.txt)
 - zero-check on ```target.call{value: value}(payload);``` . Low risk.
 [x] fixed.
 

--- a/audits/internal4/README.md
+++ b/audits/internal4/README.md
@@ -9,7 +9,7 @@ Update: 15-05-2023  <br>
 The audit focused on `HomeMediator` contract.
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal4/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal4/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -24,7 +24,7 @@ File                     |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered 
 Some of the checks are obtained automatically. They are commented and I do not see any serious problems.
 
 All automatic warnings are listed in the following file, concerns of which we address in more detail below:
-[slither-full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal4/analysis/slither_full.txt)
+[slither-full](audits/internal4/analysis/slither_full.txt)
 No issue.
 
 Notes: <br>

--- a/audits/internal5/README.md
+++ b/audits/internal5/README.md
@@ -11,7 +11,7 @@ NOTES: This audit is not an audit of the code OppenZeppelin itself. Audit of OZ 
 It is considering using the previous Timelock contract (without update) with the new version GovernorOLAS.
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal5/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal5/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -44,7 +44,7 @@ Generated png file autonolas-governance/audits/internal5/analysis/Timelock.png
 sol2uml storage . -f png -c Timelock -o ../../cur/
 Generated png file autonolas-governance/audits/internal5/analysis/cur/Timelock.png
 ```
-Line by line diff: [Timelock-flatten-diff.txt](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal5/analysis/Timelock-flatten-diff.txt)
+Line by line diff: [Timelock-flatten-diff.txt](audits/internal5/analysis/Timelock-flatten-diff.txt)
 
 Conclusion: <br>
 - No differences in the `Timelock` code which somehow changes the behavior of its functions. <br>

--- a/audits/internal6/README.md
+++ b/audits/internal6/README.md
@@ -9,7 +9,7 @@ Update: 30-08-2023  <br>
 The audit focused on Guard contract for community mutisig. <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal6/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal6/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -28,10 +28,10 @@ Using sol2uml tools: https://github.com/naddison36/sol2uml <br>
 sol2uml storage . -f png -c GuardCM -o .
 Generated png file GuardCM.png
 ```
-Storage: [GuardCM](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal6/analysis/GuardCM.png)
+Storage: [GuardCM](audits/internal6/analysis/GuardCM.png)
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal6/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal6/analysis/slither_full.txt) <br>
 Minor issue: <br>
 - lacks a zero-check on constructor
 [x] fixed - same as in other contracts, no need for the sanity check as we deploy on test networks as well

--- a/audits/internal7/README.md
+++ b/audits/internal7/README.md
@@ -9,7 +9,7 @@ Update: 27-11-2023  <br>
 The audit focused on ERC20 bridging. <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal7/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal7/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -22,7 +22,7 @@ Hardhat coverage has been performed before the audit and can be found here:
 Notes: Pay attention to coverage FxERC20RootTunnel.sol
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal7/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal7/analysis/slither_full.txt) <br>
 
 #### Bug in constructor: 
 ```solidity

--- a/audits/internal8/README.md
+++ b/audits/internal8/README.md
@@ -9,7 +9,7 @@ Update: 15-12-2023  <br>
 The audit focused on update Guard contract for community mutisig (L2 protection). <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal8/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal8/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -32,10 +32,10 @@ Using sol2uml tools: https://github.com/naddison36/sol2uml <br>
 sol2uml storage . -f png -c GuardCM -o .
 Generated png file GuardCM.png
 ```
-Storage: [GuardCM](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal8/analysis/GuardCM.png)
+Storage: [GuardCM](audits/internal8/analysis/GuardCM.png)
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal8/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal8/analysis/slither_full.txt) <br>
 
 Notes: <br>
 - chainIds[i] in constructor not checked by zero. 

--- a/audits/internal9/README.md
+++ b/audits/internal9/README.md
@@ -9,7 +9,7 @@ Update: 28-02-2024  <br>
 The audit focused on governance using native bridging to Optimism/Base and Wormhole bridging to EVM-networks supported by Standard Relayer. <BR>
 
 ### Flatten version
-Flatten version of contracts. [contracts](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal9/analysis/contracts)
+Flatten version of contracts. [contracts](audits/internal9/analysis/contracts)
 
 ### Coverage
 Hardhat coverage has been performed before the audit and can be found here:
@@ -39,7 +39,7 @@ ref: https://github.com/wormhole-foundation/hello-wormhole/blob/main/src/extensi
 [x] Good point, need to set up these parameters and call the corresponding function on the L1 Relayer (added to test scripts)
 
 ### Security issues
-Details in [slither_full](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/internal9/analysis/slither_full.txt) <br>
+Details in [slither_full](audits/internal9/analysis/slither_full.txt) <br>
 Notes: <br>
 All is false positive.
 

--- a/audits/token/README.md
+++ b/audits/token/README.md
@@ -2,11 +2,11 @@
 The Autonolas `OLAS` contract was partially or fully based on the following sources:
 - Full `ERC20` inheritance of [Rari-Capital](https://github.com/Rari-Capital/solmate) implementation
   - Last known audited version: `a9e3ea26a2dc73bfa87f0cb189687d029028e0c5`;
-  - Audit report: [solmate_audit](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/token/v6-Fixed-Point-Solutions.pdf);
-  - Changes between the last audited code and the actual one used by Autonolas clearly state that there were no major changes except for the `permit()` function linearization: [solmate_diff](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/token/SolmateDiffv6.md).
+  - Audit report: [solmate_audit](audits/token/v6-Fixed-Point-Solutions.pdf);
+  - Changes between the last audited code and the actual one used by Autonolas clearly state that there were no major changes except for the `permit()` function linearization: [solmate_diff](audits/token/SolmateDiffv6.md).
 - Adaptation of a couple of functions from [Maple Finance](https://github.com/maple-labs/erc20) `ERC20` token
   - Last known audited version: `756c110ddc3c96c596a52bce43553477a19ee3aa`;
   - Functions added to `OLAS`: `increaseAllowance()`, `decreaseAllowance()`;
-  - Changes between the last audited code and the actual one used by Autonolas: [solmate_diff](https://github.com/valory-xyz/autonolas-governance/blob/main/audits/token/MapleDiffv1.md).
+  - Changes between the last audited code and the actual one used by Autonolas: [solmate_diff](audits/token/MapleDiffv1.md).
 - Autonolas continuously gets references and inspiration from [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) set of contracts
   - Last known audited version: `136710cdd4a7b10e93b1774f086a89133f719ebe`.

--- a/docs/Vulnerabilities_list_governance.md
+++ b/docs/Vulnerabilities_list_governance.md
@@ -1,0 +1,408 @@
+# Contracts vulnerabilities
+
+## Vulnerabilities list
+
+| # | Vulnerability | Severity |
+|---|---|---|
+| 1 | [getPastVotes function](#1-getpastvotes-function) | Low |
+| 2 | [balanceOfAt function](#2-balanceofat-function) | Low |
+| 3 | [_checkpoint function](#3-_checkpoint-function) | Medium |
+| 4 | [createLockFor function](#4-createlockfor-function) | Medium |
+| 5 | [totalSupplyLockedAtT function](#5-totalsupplylockedatt-function) | Low |
+| 6 | [getPastTotalSupply function](#6-getpasttotalsupply-function) | Low |
+| 7 | [processMessageFromForeign function](#7-processmessagefromforeign-function) | Informative |
+| 8 | [removeNominee function](#8-removenominee-function) | Low |
+| 9 | [_addNominee and removeNominee functions](#9-_addnominee-and-removenominee-functions) | Informative |
+| 10 | [voteForNomineeWeights function](#10-voteforNomineeweights-function) | Informative |
+
+## Involved contracts and level of the bugs
+
+The present document aims to point out some vulnerabilities in the contracts veOLAS,
+buOLAS, and VoteWeighting. Some of these vulnerabilities may lead to critical[^1] bugs.
+
+## Vulnerabilities
+
+### 1. `getPastVotes` function
+
+**Acknowledgments:** This vulnerability was discovered thanks to [howd4ys](https://immunefi.com/) who kindly
+reported it by participating in the [Autonolas Immunefi Bug Program](https://immunefi.com/).
+
+**Severity:** Low[^2]
+
+In the veOLAS contract, the following function is implemented:
+
+```solidity
+function getPastVotes(address account, uint256 blockNumber) public view override returns (uint256 balance)
+```
+
+This function returns the voting power of the address `account` at a specific `blockNumber`.
+
+This function has an incorrect behavior when the input `blockNumber` is smaller than the
+block number `n` where a lock was first created for the `account`.
+
+Specifically, denoting by `T` the timestamp of the input `blockNumber` and `T1` the
+timestamp of the block `n`, the incorrect behavior arises because of the subtraction
+veOLAS.sol#L680 that becomes an addition when `blockTime=T` is smaller than
+`uPoint.ts=T1`. Denoting by `T2` the `endTime` for the locking created for the `account` at
+time `T1`, the calculation in veOLAS.sol#L680 provides the following value for the bias
+`bias=slope*(T2-T)`. However, the latter bias is bigger than the correct value for the
+bias at the timestamp `T1` which should be `slope*(T2-T1)`.
+
+We recommend using as an input parameter of the function a `blockNumber` bigger than
+the block number `n` where a lock was first created for the `account`.
+
+Note that the function `getPastVotes(account,blockNumber)` is used to weigh the
+voting power of users that cast a vote on a governance proposal. Whether there is a
+governance proposal and a user creates a lock after the beginning and no later than the
+end of the voting period, due to this vulnerability of
+`getPastVotes(account,blockNumber)`, the user would be able to cast a voting power
+bigger than its correct one. Note that the manipulation of the voting power has an upper
+bound due to the fact that there is a limited number of blocks in a voting period and that
+any locks last at least one week. Nevertheless, currently, there is no possibility of creating
+new locks, so this issue cannot affect any governance voting.
+
+The wrapped veOLAS (wveOLAS) contract wraps original veOLAS view functions and
+serves as mitigating measures to address this issue.
+
+### 2. `balanceOfAt` function
+
+**Severity:** Low[^3]
+
+In the veOLAS contract, the following function is implemented:
+
+```solidity
+function balanceOfAt(address account, uint256 blockNumber) external view returns (uint256 balance)
+```
+
+This function returns the actual balance of the address `account` at a specific `blockNumber`.
+
+This function has an incorrect behavior when the input `blockNumber` is smaller than the
+block number `n` where a lock was first created for the `account`.
+
+As for the previous vulnerability explanation (`getPastVotes()`), the function
+`balanceOfAt()` uses the same binary search algorithm followed by identical value
+extraction, and thus returns a very first balance of a locked point, whereas it should return
+zero.
+
+We recommend using `blockNumber` input parameter value bigger than the block number
+`n` where a lock was first created for the `account`.
+
+The wrapped veOLAS (wveOLAS) contract wraps original veOLAS view functions and
+serves as mitigating measures to address this issue.
+
+### 3. `_checkpoint` function
+
+**Severity:** Medium[^4]
+
+In the veOLAS contract, the following function is implemented:
+
+```solidity
+function _checkpoint(address account, LockedBalance memory oldLocked, LockedBalance memory newLocked, uint128 curSupply) internal
+```
+
+According to the article on [medium.com](https://medium.com), the declaration of a memory struct *lastPoint* and
+its assignment to another memory struct leads to the pointer of the initial struct, and not
+its deep copy, that can be observed in line 219. This leads to the incorrect calculations of
+history points for the periods of time when there was no *checkpoint()* function called for
+more than a week.
+
+However, there is more to the specified issue that leads to following observations:
+
+- If the contract has not created a user point during a specific week, then when
+  finally created, the internal checkpoint function writes a point in that week with the
+  block number equal to the last created point but with a timestamp equal to the end
+  time of the week that has just passed. If no points were created for several weeks,
+  then the internal checkpoint function recreates a point for each week of inactivity
+  having the block number equal to the last created user point and the timestamp
+  equal to the end time of the end of each skipped week.
+- Even if the checkpoint is called once a week, two points are created: one point
+  with a block number equal to the last created point but with a timestamp equal to
+  the end time of the week, and another one with an actual block number and
+  corresponding timestamp of the checkpoint call.
+
+This behavior leads to the creation of supply points that have an incorrect block number
+detached from the actual timestamp. This further leads to the scenario where all supply
+points during the weeks of inactivity of veOLAS have the same block numbers as the first
+point that triggered the *checkpoint()*. In other words, all the supply points that were
+recreated at the end time of every week will not be correctly recovered during the block
+number search (via the block number itself or the timestamp). Any historic lookups
+between two supply points (not including points themselves) that were created
+immediately before and immediately later the exact end of a week or that were created
+with more than a week of inactivity will have an incorrect block number equal to the one
+of a first point.
+
+This might potentially affect the voting functionality. If the voting was performed during
+the time that had to account for the inactivity weeks, immediately after the very last point
+before the end time of a week, or immediately after an eventful point was created at the
+end time of a week, the weighted total supply (the overall number of votes) in the function
+*getPastTotalSupply()* **might** return incorrect values (depending on the first point with the
+same block number found via a binary search).
+
+In the absence of deploying new contracts, we recommend running the analogue of the
+cron scheduler / service that checks for the veOLAS activity during the week, and if there
+was none, trigger a *checkpoint()* function call immediately before and immediately after
+end time of each week. This way, all the supply points will be updated throughout the time
+of the contract and, we increase the likelihood of having voting periods starting
+immediately after and before effective points with different blocks timestamps (not in the
+weekly time divider). As the protocol becomes more active, this issue will be minimized by
+the participation of DAO members.
+
+To minimize a possible impact, the service triggering the *checkpoint()* call must be
+executed as close to the whole week of unix time as possible. Specifically, if the
+checkpoint is called at least once a week, a possible deviation in the total voting supply
+can only happen if the vote starts after the very last point of week (not in the weekly time
+divider) or before the very first point of a week. The supply deviation factor depends on
+the time difference between the very last weekly point (not in the weekly end divider) and
+the very first point after the weekly end time divider point.
+
+Therefore, calling checkpoints as closer to the end and the beginning of the week of unix
+time as possible the supply deviation can be minimized. A probabilistic analysis of how
+likely such a scenario can happen is out of the scope of this document. However, despite
+its likelihood, it is worth mentioning that, even in such a scenario, there is no certainty that
+the wrong point will be picked by the binary search and ultimately there is no certainty
+that the issue is going to affect the expected result.
+
+### 4. `createLockFor` function
+
+**Severity:** Medium
+
+In veOLAS and buOLAS contracts, the following function is implemented:
+
+```solidity
+function createLockFor(address account, uint256 amount, uint256 unlockTime) external
+```
+
+This function allows anyone, even a smart contract, to create a lock for a third-party
+`account`. If the third-party `account` has already a locked amount the call will be reverted.
+If not and the OLAS amount provided as input is non-zero then a lock is created.
+
+As a consequence, any third-party account can be forced into a long lock length (for a
+maximum of 4 years for veOLAS and 10 years for buOLAS) by an attacker calling
+`createLockFor` with a very small amount of OLAS (i.e. 1/10^18) and a max lock length.
+An attacker could use this to prevent locks over a given adversarially chosen interval by
+front-running all locks in this manner. All accounts with an intent to lock for less than 4
+years would be affected. We assign a low likelihood to this attack, as it is not
+economically profitable for the attacker.
+
+Indeed, the caller of the `createLockFor` function can lock for third-party users only by
+using its own OLAS tokens. So the mintable OLAS tokens can be temporarily frozen only
+with an attacker's extensive cost.
+
+In the buOLAS contract, there is also an extra guardrail that can be considered. If the
+attack has been discovered, it is possible to invoke a governance vote to revoke the
+unvested OLAS of the third-party account that has been forced in a long lock into
+buOLAS. If the governance approves the revoke, the third-party account can call the
+buOLAS withdraw function, and all non-vested OLAS tokens will be burned. When the
+withdrawal function is called less than one year after the attack, all the contract status
+can return to their original status before the attack has been made.
+
+### 5. `totalSupplyLockedAtT` function
+
+**Severity:** Low
+
+In the veOLAS contract, the following function is implemented:
+
+```solidity
+function totalSupplyLockedAtT(uint256 ts) public view returns (uint256)
+```
+
+The function is used solely by the `totalSupplyLocked()` function with the current
+`block.timestamp`. By the original design, it is not intended to have a `ts` parameter
+smaller than the current `block.timestamp`.
+
+We recommend not to call this function for any external purposes. It is a view function
+that is not currently used externally in any of Autonolas on-chain protocol contracts, and
+thus does not affect any intended behavior.
+
+The wrapped veOLAS (wveOLAS) contract wraps original veOLAS view functions and
+serves as mitigating measures to address this issue.
+
+### 6. `getPastTotalSupply` function
+
+**Severity:** Low
+
+In the veOLAS contract, the following function is implemented:
+
+```solidity
+function getPastTotalSupply(uint256 blockNumber) external view returns (uint256)
+```
+
+The function returns the voting power of a specified block number. However, by the
+original implementation, the requested block number must be at least equal to the zero
+supply point block number, or the block number of a contract deployment. Otherwise, the
+function reverts instead of returning a zero value.
+
+We recommend not to call this function with the input block number value less than a zero
+supply point block number, since it is meaningless anyway as there must be no values
+before the very first supply point is created in the contract.
+
+### 7. `processMessageFromForeign` function
+
+**Severity:** Informative
+
+In the HomeMediator contract, the following function is implemented:
+
+```solidity
+function processMessageFromForeign(bytes memory data) external
+```
+
+The role of HomeMediator contract is to execute actions based on governance proposals
+originating from Ethereum. This execution is rigorously bound to governance decisions,
+with the validation of the message sender being restricted to the Timelock address on
+Ethereum.
+
+In the current implementation, the `processMessageFromForeign()` method ensures
+that the `msg.sender` aligns with the Ethereum Timelock address. However, it does not
+enforce a verification of the source `chainId` to match Ethereum's `chainId`. This poses
+no immediate issues as the arbitrary message bridge contract, facilitating communication
+between Ethereum and Gnosis, exclusively processes requests from the Ethereum chain.
+
+For future scenarios where the arbitrary message bridge contract might handle requests
+from diverse chains (as outlined in the [doc](https://docs.gnosischain.com/)), it is recommended to improve the
+implementation of HomeMediator's `processMessageFromForeign()` method by
+incorporating a `chainId` check.
+
+### 8. `removeNominee` function
+
+**Severity:** Low
+
+In the VoteWeighting contract, the following function is implemented:
+
+```solidity
+function removeNominee(bytes32 account, uint256 chainId) external
+```
+
+The `removeNominee()` function is designed to remove a nominee from the system. This
+operation is restricted to the contract owner.
+
+Whether the nominee exists, the nominee's current weight is then set to zero for the next
+checkpoint time. The total weight sum is updated to reflect the removal of the nominee's
+weight. If a dispenser contract is configured, the function calls the `removeNominee`
+method on the dispenser to ensure this is aware of the removal.
+
+If a nominee is removed and users have allocated non-zero weight to that nominee, the
+associated voting power becomes orphaned. The contract doesn't automatically retrieve
+or reallocate user voting power within the `removeNominee()` function itself. However,
+users can reclaim their voting power using the
+`retrieveRemovedNomineeVotingPower()` function. It's advisable for voters to update
+a non-zero weight of their nominee to zero before the nominee's removal is expected to
+happen or to reclaim their vote after the nominee's removal has occurred.
+
+Additionally, when a nominee is removed, the last nominee in the set will take the place of
+the removed nominee, changing its ID at the end of the `removeNominee()` call. It's
+important to note that the same ID can correspond to different nominees at different
+times, depending on removals.
+
+Beyond orphaned voting power, `removeNominee()` has a deeper accounting defect
+related to slope and `changesSum` cleanup. When a user votes for a nominee, their slope is
+added to both:
+- `pointsWeight[nomineeHash]` — the nominee's individual weight;
+- `pointsSum` — the total weight across all nominees.
+
+And a scheduled slope change is written to:
+- `changesWeight[nomineeHash][lockEnd]` — cleared on revocation;
+- `changesSum[lockEnd]` — NOT cleared on removal or revocation
+
+`removeNominee()` zeroes the nominee's bias but leaves the slope intact
+(VoteWeighting.sol lines 603–613). It does NOT iterate over voters to clean `changesSum`
+entries. The assumption is that voters will call `revokeRemovedNomineeVotingPower()`
+to clean up.
+
+**Impact scenario (DoS):**
+
+1. Voters allocate weight to nominee N with locks expiring at various future times.
+2. Owner calls `removeNominee(N)` — bias zeroed, slope untouched.
+3. Voters let their veOLAS locks expire WITHOUT calling
+   `revokeRemovedNomineeVotingPower()` (they have no strong economic
+   incentive to do so for a removed nominee).
+4. `changesSum` entries remain permanently — each time `_getSum()` iterates past a
+   lock expiry, it subtracts the phantom slope from the sum.
+5. Over time, `_getSum()` floors at zero via the guard:
+   `if (pt.bias > dBias) { pt.bias -= dBias; } else { pt.bias = 0; pt.slope = 0; }`.
+6. Meanwhile, individual nominee weights (for still-active nominees) do NOT floor at
+   zero — they reflect real votes. So `oldWeight > 0` while `oldSum == 0`.
+7. When owner tries to `removeNominee()` for another nominee:
+   `uint256 newSum = oldSum - oldWeight; // line 611: 0 - X → UNDERFLOW REVERT`
+8. This reverts, making it impossible to remove any more nominees.
+
+`_getSum()` line 237 is also unprotected: `pt.slope -= dSlope;`
+If `changesSum[t] > pt.slope` at a point where `bias > dBias`, `_getSum()` itself
+would revert.
+
+**Practical feasibility:**
+
+- `removeNominee()` requires a governance proposal through GovernorOLAS →
+  Timelock — a rare, deliberate action.
+- Voters of the removed nominee must NOT call
+  `revokeRemovedNomineeVotingPower()`. Voters do have some incentive to
+  revoke (they regain voting power to reallocate), but passive voters who locked
+  OLAS, voted once, and forgot may never do so.
+- Enough time must pass for phantom slopes to drain the sum to zero (locks last up
+  to 4 years).
+- Owner tries to `removeNominee()` for another nominee while `sum == 0` and that
+  nominee's individual `weight > 0`.
+
+**Workarounds (without contract redeployment):**
+
+1. **Voter cleanup before each removal (recommended):** Before submitting a
+   governance proposal for `removeNominee(B)`, identify all voters who voted for
+   previously-removed nominees and haven't revoked (read `VoteForNominee` /
+   `VotingPowerRevoked` events). Contact these voters and ask them to call
+   `revokeRemovedNomineeVotingPower()`. Note that revoke must happen
+   BEFORE the voter's lock expires — if `oldSlope.end > block.timestamp`, full cleanup
+   occurs; if the lock already expired, the `changesSum` entry was already processed
+   and the phantom subtraction is permanent.
+2. **Two-step removal with vote-zeroing:** Request all voters of nominee X to set
+   `weight=0` via `voteForNomineeWeights(X, chainId, 0)` first, which properly
+   cleans up slopes and `changesSum` via the standard vote path. Then
+   `removeNominee(X)` with `oldWeight ≈ 0` avoids underflow.
+3. **Health monitoring:** Deploy off-chain monitoring that tracks `pointsSum` vs. sum of
+   individual `pointsWeight` for all active nominees, plus unrevoked voters for
+   removed nominees and time until their locks expire.
+
+### 9. `_addNominee` and `removeNominee` functions
+
+**Severity:** Informative
+
+In the VoteWeighting contract, the following functions are implemented:
+
+```solidity
+function _addNominee(Nominee memory nominee) internal
+function removeNominee(bytes32 account, uint256 chainId) external
+```
+
+The `removeNominee()` function is designed to remove a nominee from the system, and
+this operation is restricted to the contract owner. On the other hand, `_addNominee()`
+adds a nominee to the system.
+
+In both cases, if a Dispenser is configured, these functions respectively call the
+`addNominee()` and `removeNominee()` methods on the dispenser contract. This ensures
+that the dispenser is kept informed about any nominees being added or removed.
+
+It's highly recommended for the deployer to set up a dispenser contract immediately after
+deploying VoteWeighting and ensure that no nominees were added or removed before
+that. This precaution helps prevent potential synchronization issues between nominees on
+the VoteWeighting and Dispenser contracts.
+
+### 10. `voteForNomineeWeights` function
+
+**Severity:** Informative
+
+In the VoteWeighting contract, the following function is implemented:
+
+```solidity
+function voteForNomineeWeights(bytes32 account, uint256 chainId, uint256 weight) public
+```
+
+The function is designed to allocate voting power for changing pool weights. Note that
+following the original Curve implementation, the function reverts if the next time of
+recording weights is equal to the end of veOLAS lock (reverts if `nextTime >= lockEnd`).
+In case of equality, the voting account is not able to place their weights as
+their veOLAS lock expires in a week. We consider this not to be an issue, as one week
+of time results in a very low voting power addition, and the lock can always be extended
+for longer in order to make a bigger weighting input.
+
+[^1]: The level of the bug is assigned by following the [Immunefi classification](https://immunefi.com/).
+[^2]: Since no manipulation of governance voting can currently happen, this vulnerability identifies a smart contract that fails to deliver promised returns but doesn't lose value.
+[^3]: This function is not currently used in any of the Autonolas on-chain contracts, thus this vulnerability identifies a smart contract that fails to deliver promised returns but doesn't lose value.
+[^4]: When voting via veOLAS, the incorrect value is returned as a read-only value, thus this could be declared as a Low severity. However, if there are consequences due to incorrect voting failure, then it is a potential damage to the DAO members, and then the severity is Medium.

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -1,5 +1,5 @@
 # Deployment scripts
-This folder contains the scripts to deploy Autonolas governance. These scripts correspond to the steps in the full deployment procedure (as described in [deployment.md](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/deployment.md)).
+This folder contains the scripts to deploy Autonolas governance. These scripts correspond to the steps in the full deployment procedure (as described in [deployment.md](docs/deployment.md)).
 
 ## Observations
 - There are several files with global parameters based on the corresponding network. In order to work with the configuration, please copy `gobals_network.json` file to file the `gobals.json` one, where `network` is the corresponding network. For example: `cp gobals_mainnet.json gobals.json`.
@@ -18,7 +18,7 @@ command and compiled with the
 ```
 npx hardhat compile
 ```
-command as described in the [main readme](https://github.com/valory-xyz/autonolas-governance/blob/main/README.md).
+command as described in the [main readme](README.md).
 
 
 Create a `globals.json` file in the root folder, or copy it from the file with pre-defined parameters (i.e., `scripts/deployment/globals_mainnet.json` for the mainnet).
@@ -34,7 +34,7 @@ Parameters of the `globals.json` file:
 Other values are related to the governance and initial mint. The Gnosis Safe contracts are also provided for convenience. The deployed contract addresses will be added / updated during the scripts run.
 
 The script file name identifies the number of deployment steps taken up to the number in the file name. For example:
-- `deploy_02_deployment_factory.js` will complete step 2 from [deployment.md](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/deployment.md) (1 is already complete as the multisig is created beforehand);
+- `deploy_02_deployment_factory.js` will complete step 2 from [deployment.md](docs/deployment.md) (1 is already complete as the multisig is created beforehand);
 - `deploy_08_09_governor_and_roles.js` will complete steps 8 and 9;
 - etc.
 
@@ -51,7 +51,7 @@ Each script controls the obtained values by checking them against the expected o
 If a contract is deployed with arguments, these arguments are taken from the corresponding `verify_number_and_name` file, where `number_and_name` corresponds to the deployment script number and name.
 
 ## Deployment of supplemental contracts
-For deploying supplemental contracts listed in [deployment.md](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/deployment.md),
+For deploying supplemental contracts listed in [deployment.md](docs/deployment.md),
 run the following scripts:
 ```
 npx hardhat run scripts/deployment/deploy_16_wveolas.js --network network_type
@@ -62,7 +62,7 @@ Then, after successful deployment of two supplemental contracts, the last script
 `npx hardhat run scripts/deployment/deploy_18_governor_to_governorTwo.js --network network_type`.
 
 ## Deployment of Polygon-Ethereum ERC20 bridging contracts
-For deploying ERC20 bridging contracts listed in [deployment.md](https://github.com/valory-xyz/autonolas-governance/blob/main/docs/deployment.md),
+For deploying ERC20 bridging contracts listed in [deployment.md](docs/deployment.md),
 run the following scripts:
 ```
 npx hardhat run scripts/deployment/deploy_19_bridged_erc20.js --network mainnet

--- a/scripts/deployment/bridges/gnosis/README.md
+++ b/scripts/deployment/bridges/gnosis/README.md
@@ -1,5 +1,5 @@
 # Bridge-related deployment scripts
-This process is the same as described in the original deployment procedure: [deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+This process is the same as described in the original deployment procedure: [deployment](scripts/deployment).
 
 ## Steps to engage
 The project has submodules to get the dependencies. Make sure you run `git clone --recursive` or init the submodules yourself.
@@ -38,7 +38,7 @@ If a contract is deployed with arguments, these arguments are taken from the cor
 
 ## Data packing for cross-bridge transactions
 In order to correctly pack the data and supply it to the Timelock such that it is correctly processed across the bridge,
-use the following script: [cross-bridge data packing](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/pack-data.js).
+use the following script: [cross-bridge data packing](scripts/deployment/bridges/pack-data.js).
 
 
 

--- a/scripts/deployment/bridges/optimism/README.md
+++ b/scripts/deployment/bridges/optimism/README.md
@@ -1,5 +1,5 @@
 # Bridge-related deployment scripts
-This process is the same as described in the original deployment procedure: [deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+This process is the same as described in the original deployment procedure: [deployment](scripts/deployment).
 
 ## Steps to engage
 The project has submodules to get the dependencies. Make sure you run `git clone --recursive` or init the submodules yourself.
@@ -42,7 +42,7 @@ where `number_and_name` corresponds to the deployment script number and name.
 
 ## Data packing for cross-bridge transactions
 In order to correctly pack the data and supply it to the Timelock such that it is correctly processed across the bridge,
-use the following script: [cross-bridge data packing](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/pack-data.js).
+use the following script: [cross-bridge data packing](scripts/deployment/bridges/pack-data.js).
 
 
 

--- a/scripts/deployment/bridges/polygon/README.md
+++ b/scripts/deployment/bridges/polygon/README.md
@@ -1,5 +1,5 @@
 # Bridge-related deployment scripts
-This process is the same as described in the original deployment procedure: [deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+This process is the same as described in the original deployment procedure: [deployment](scripts/deployment).
 
 ## Steps to engage
 The project has submodules to get the dependencies. Make sure you run `git clone --recursive` or init the submodules yourself.
@@ -37,7 +37,7 @@ If a contract is deployed with arguments, these arguments are taken from the cor
 
 ## Data packing for cross-bridge transactions
 In order to correctly pack the data and supply it to the Timelock such that it is correctly processed across the bridge,
-use the following script: [cross-bridge data packing](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/pack-data.js).
+use the following script: [cross-bridge data packing](scripts/deployment/bridges/pack-data.js).
 
 
 

--- a/scripts/deployment/bridges/wormhole/README.md
+++ b/scripts/deployment/bridges/wormhole/README.md
@@ -1,5 +1,5 @@
 # Bridge-related deployment scripts
-This process is the same as described in the original deployment procedure: [deployment](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment).
+This process is the same as described in the original deployment procedure: [deployment](scripts/deployment).
 
 ## Steps to engage
 The project has submodules to get the dependencies. Make sure you run `git clone --recursive` or init the submodules yourself.
@@ -43,7 +43,7 @@ where `number_and_name` corresponds to the deployment script number and name.
 
 ## Data packing for cross-bridge transactions
 In order to correctly pack the data and supply it to the Timelock such that it is correctly processed across the bridge,
-use the following script: [cross-bridge data packing](https://github.com/valory-xyz/autonolas-governance/blob/main/scripts/deployment/bridges/pack-data.js).
+use the following script: [cross-bridge data packing](scripts/deployment/bridges/pack-data.js).
 
 
 


### PR DESCRIPTION
## Summary
- Convert `docs/Vulnerabilities_list_governance.pdf` to `docs/Vulnerabilities_list_governance.md` (10 known unaddressed issues only)
- Replace all absolute GitHub URLs (`https://github.com/valory-xyz/autonolas-governance/blob/main/...`) with relative paths across 22 markdown files
- Update all references from `.pdf` to `.md` for the vulnerabilities list

## Test plan
- [x] Verify all relative links resolve correctly on GitHub
- [x] Verify the new `.md` vulnerabilities list renders properly