### PR TITLE
audit: internal19 disposition matrix + 2 vulnerabilities + EIP-170 fix

### DIFF
--- a/audits/internal19/README.md
+++ b/audits/internal19/README.md
@@ -14,7 +14,7 @@ The C4A 2026-01 contest covers the whole Olas mono-org (`autonolas-tokenomics`, 
 |---|---|---|---|---|
 | **S-629 (= M-01)** | Arbitrum bridge — `ProcessBridgedDataArbitrum.processBridgeData` decoded but did not validate `l2CallValue`, `excessFeeRefundAddress`, `callValueRefundAddress`; a CM-scheduled proposal could redirect L2 refunds/call-value to an attacker | ✅ **Fixed in `origin/main`** | ⚪ **Code fix only — never deployed** (modular `bridge_verifier/*` pattern is brand-new; will land on-chain together with the pending GuardCM / GovernorOLAS redeployment, see §5.4) | [`4fd7d98`](https://github.com/valory-xyz/autonolas-governance/commit/4fd7d9896332c3cc5b00de8d67f402cb70c154f9) — branch `audit_fixes`, PR [#185](https://github.com/valory-xyz/autonolas-governance/pull/185) |
 
-The remaining **22 H + M findings** (11H + 11M) and **15 Lows** target `autonolas-tokenomics` or `autonolas-registries`. Per-finding code status, deployment status (where the responsible repo's snapshot expresses one), and per-repo handoff are enumerated row-by-row in **§4 — C4A 2026-01 verification matrix**. Details of the S-629 / M-01 fix verification are in §4.1.
+The remaining **22 H + M findings** (11H + 11M) target `autonolas-tokenomics` or `autonolas-registries` and are enumerated row-by-row in **§4 — C4A 2026-01 verification matrix**; the **15 Lows** are disclosed at aggregate level in §4.0.1. Per-finding code status, deployment status (where the responsible repo's snapshot expresses one), and per-repo handoff are recorded in those sections. Details of the S-629 / M-01 fix verification are in §4.1.
 
 **Status vocabulary (used in §4 matrix and elsewhere in this report):**
 
@@ -77,7 +77,7 @@ The C4A 2026-01 report is repo-wide across the Olas mono-org. Every finding was 
 
 ### 4.0 Full disposition (High + Medium, n = 23 = 11H + 12M)
 
-Source: filtered C4A status snapshot `full_report_2026-01-olas.md` in this repo's working tree (`severity = high|medium`, baseline `origin/main` as of 2026-04-10; `fix_oracle_v2` branch noted where applicable for tokenomics).
+Source: filtered C4A status snapshot — an **external/local audit input**, not committed to this repository. Derived from the C4A 2026-01 submissions index ([`code4rena.com/evaluate/j3PRAMM3fVq`](https://code4rena.com/evaluate/j3PRAMM3fVq)) and filtered to `severity = high|medium`, baseline `origin/main` as of 2026-04-10; `fix_oracle_v2` branch noted where applicable for tokenomics. Reproducing the snapshot from scratch requires re-running that filter against the C4A submissions index — the table below preserves every per-row attribute (sev, repo, status, fix-commit link) needed to re-derive it.
 
 The **Code status** column says where in the source tree the fix lives; the **Deployment status** column says whether that fix is live on-chain. The two are independent and used to be conflated in the prior version of this matrix — the conflation is exactly what this split is meant to resolve. Vocabulary is defined in §0.
 
@@ -130,9 +130,9 @@ The **Code status** column says where in the source tree the fix lives; the **De
 
 ### 4.0.1 Lows (n = 15) — disposition
 
-The 15 Low findings from the C4A 2026-01 report were **not individually enumerated** in the filtered status snapshot used as input here (`full_report_2026-01-olas.md` was filtered to `severity = high|medium` for the H/M handoff round). Per the per-submission repo classification we ran during C4A triage, **none of the 15 Lows landed on a governance-repo contract** — they cluster in `autonolas-tokenomics` (oracle / liquidity-manager paths) and `autonolas-registries` (staking / service-manager paths), and are tracked under those repos' Low-severity handoffs.
+The 15 Low findings from the C4A 2026-01 report were **not individually enumerated** in the filtered status snapshot used as input here (the external/local snapshot referenced in §4.0 was filtered to `severity = high|medium` for the H/M handoff round). Per the per-submission repo classification we ran during C4A triage, **none of the 15 Lows landed on a governance-repo contract** — they cluster in `autonolas-tokenomics` (oracle / liquidity-manager paths) and `autonolas-registries` (staking / service-manager paths), and are tracked under those repos' Low-severity handoffs.
 
-**Honest gap-disclosure:** if a future hygiene pass requires per-ID rows for the 15 Lows in this matrix (with S-IDs, summaries, and current statuses), the C4A submissions index for the 2026-01 contest is the source of truth and the snapshot would need to be re-imported with the severity filter relaxed. The aggregate claim "0 Lows are governance-scope" stands on the repo classification we performed; the per-row enumeration does not appear in this document because it never entered the input snapshot we worked from.
+**Honest gap-disclosure:** if a future hygiene pass requires per-ID rows for the 15 Lows in this matrix (with S-IDs, summaries, and current statuses), the C4A submissions index for the 2026-01 contest ([`code4rena.com/evaluate/j3PRAMM3fVq`](https://code4rena.com/evaluate/j3PRAMM3fVq)) is the source of truth and the snapshot would need to be re-imported with the severity filter relaxed. The aggregate claim "0 Lows are governance-scope" stands on the repo classification we performed; the per-row enumeration does not appear in this document because it never entered the input snapshot we worked from.
 
 **Disposition summary (Lows):** 0 governance-scope, 15 tracked in `autonolas-tokenomics` / `autonolas-registries` (per-ID details in those repos' audit handoffs).
 

--- a/audits/internal19/README.md
+++ b/audits/internal19/README.md
@@ -8,11 +8,31 @@ Prior reference: `audits/internal18/README.md`
 
 ## 0. C4A 2026-01 findings summary (governance-scope)
 
-| C4A ID | Summary | Fixed? | Fix commit |
-|---|---|---|---|
-| **M-01** | Arbitrum bridge — `ProcessBridgedDataArbitrum.processBridgeData` decoded but did not validate `l2CallValue`, `excessFeeRefundAddress`, `callValueRefundAddress`; a CM-scheduled proposal could redirect L2 refunds/call-value to an attacker | ✅ **FIXED** | [`4fd7d98`](https://github.com/valory-xyz/autonolas-governance/commit/4fd7d9896332c3cc5b00de8d67f402cb70c154f9) — branch `audit_fixes`, PR [#185](https://github.com/valory-xyz/autonolas-governance/pull/185) |
+The C4A 2026-01 contest covers the whole Olas mono-org (`autonolas-tokenomics`, `autonolas-registries`, `autonolas-governance`). Of the 23 confirmed H + M findings (11H + 12M), exactly **one** lands on a contract in this repository:
 
-All other C4A 2026-01 findings (11H + 11M + 15L + disclosures) target other Olas repos and are out of scope for this audit; see §4 for the full triage. Details of the M-01 fix verification are in §4.1.
+| C4A ID | Summary | Code status | Deployment status | Reference |
+|---|---|---|---|---|
+| **S-629 (= M-01)** | Arbitrum bridge — `ProcessBridgedDataArbitrum.processBridgeData` decoded but did not validate `l2CallValue`, `excessFeeRefundAddress`, `callValueRefundAddress`; a CM-scheduled proposal could redirect L2 refunds/call-value to an attacker | ✅ **Fixed in `origin/main`** | ⚪ **Code fix only — never deployed** (modular `bridge_verifier/*` pattern is brand-new; will land on-chain together with the pending GuardCM / GovernorOLAS redeployment, see §5.4) | [`4fd7d98`](https://github.com/valory-xyz/autonolas-governance/commit/4fd7d9896332c3cc5b00de8d67f402cb70c154f9) — branch `audit_fixes`, PR [#185](https://github.com/valory-xyz/autonolas-governance/pull/185) |
+
+The remaining **22 H + M findings** (11H + 11M) and **15 Lows** target `autonolas-tokenomics` or `autonolas-registries`. Per-finding code status, deployment status (where the responsible repo's snapshot expresses one), and per-repo handoff are enumerated row-by-row in **§4 — C4A 2026-01 verification matrix**. Details of the S-629 / M-01 fix verification are in §4.1.
+
+**Status vocabulary (used in §4 matrix and elsewhere in this report):**
+
+| Code status | Meaning |
+|---|---|
+| ✅ Fixed in `origin/main` | Code fix landed on the responsible repo's `origin/main` |
+| 🟢 Fixed on feature branch | Code fix landed on a non-`main` feature branch (e.g., `fix_oracle_v2`); not yet merged |
+| 🟠 Partially fixed | Some attack paths closed in code, others still live |
+| 📝 Documented (known issue) | Not fixed; explicitly accepted on the responsible repo's vulnerabilities-list |
+| 🔴 Not fixed (open) | Not fixed in code; not documented as accepted; tracked openly |
+
+| Deployment status | Meaning |
+|---|---|
+| 🟢 Live on-chain | Code fix is deployed and live on the responsible repo's target chain(s) |
+| 🟡 Pending redeploy | Code fix landed; the on-chain version is still the older code; redeployment of an existing contract required to land the fix |
+| ⚪ Code fix only — never deployed | Code fix exists; the affected contract has no prior on-chain version (brand-new file or never-shipped contract) |
+| — (N/A) | Code is not fixed (not applicable) |
+| Not verified here | This report did not verify the on-chain deployment state of the responsible repo's fix — see that repo's handoff |
 
 ## 1. Objectives
 
@@ -51,17 +71,79 @@ All of these were read fresh in this session (task #79).
 5. **Vulnerabilities_list_governance.md hygiene** — re-check all 10 entries against code.
 6. **Internal18 findings check** — for each internal18 finding, confirm status on HEAD.
 
-## 4. C4A 2026-01 verification matrix (governance-scope only)
+## 4. C4A 2026-01 verification matrix
 
-The C4A 2026-01 report covers all Olas repos. Every finding was classified by the contract it touches; only one item lands on a governance contract.
+The C4A 2026-01 report is repo-wide across the Olas mono-org. Every finding was classified by the contract / repository it touches. The full disposition table below makes explicit, per finding, (a) which repo owns the fix, (b) whether it is governance-scope, and (c) the final status — fixed, partially fixed, accepted as a known issue (vulnerabilities-list), or not fixed and tracked in the responsible repo.
 
-| C4A ID | Title | Target | Governance-scope? |
-|---|---|---|---|
-| **M-01** | **Arbitrum bridge — unchecked `l2CallValue` / refund addresses in `ProcessBridgedDataArbitrum`** | **autonolas-governance** | ✅ **YES** |
+### 4.0 Full disposition (High + Medium, n = 23 = 11H + 12M)
 
-All other C4A entries (11H + 11M + 15L + disclosures) target other Olas repos and are out of scope for this audit.
+Source: filtered C4A status snapshot `full_report_2026-01-olas.md` in this repo's working tree (`severity = high|medium`, baseline `origin/main` as of 2026-04-10; `fix_oracle_v2` branch noted where applicable for tokenomics).
 
-**Result: exactly one C4A finding — M-01 — is governance-scope.**
+The **Code status** column says where in the source tree the fix lives; the **Deployment status** column says whether that fix is live on-chain. The two are independent and used to be conflated in the prior version of this matrix — the conflation is exactly what this split is meant to resolve. Vocabulary is defined in §0.
+
+| C4A ID | Sev | Repo | Gov-scope? | Code status | Deployment status | Reference |
+|---|---|---|---|---|---|---|
+| [S-229](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-229)   | H | autonolas-registries | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-registries` — out of scope for this report |
+| [S-248](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-248)   | H | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`33468a4`](https://github.com/valory-xyz/autonolas-tokenomics/commit/33468a4) |
+| [S-347](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-347)   | H | autonolas-tokenomics | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-tokenomics` — out of scope for this report |
+| [S-471](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-471)   | H | autonolas-tokenomics | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-tokenomics` — out of scope for this report |
+| [S-578](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-578)   | H | autonolas-registries | No | ✅ Fixed in `origin/main` | Not verified here | [`7674c5c9`](https://github.com/valory-xyz/autonolas-registries/commit/7674c5c9) |
+| [S-847](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-847)   | H | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`0948e8b`](https://github.com/valory-xyz/autonolas-tokenomics/commit/0948e8b) |
+| [S-853](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-853)   | H | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`33468a4`](https://github.com/valory-xyz/autonolas-tokenomics/commit/33468a4) |
+| [S-858](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-858)   | H | autonolas-registries | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-registries` — out of scope for this report |
+| [S-862](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-862)   | H | autonolas-registries | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-registries` — out of scope for this report |
+| [S-1068](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1068) | H | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`33468a4`](https://github.com/valory-xyz/autonolas-tokenomics/commit/33468a4) |
+| [S-1187](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1187) | H | autonolas-registries | No | 🟠 Partially fixed | Not verified here | [`7674c5c9`](https://github.com/valory-xyz/autonolas-registries/commit/7674c5c9) — ServiceManager guarded; StakingBase paths unchanged |
+| [S-256](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-256)   | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`0948e8b`](https://github.com/valory-xyz/autonolas-tokenomics/commit/0948e8b) |
+| **[S-629](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-629) (= M-01)** | **M** | **autonolas-governance** | **✅ Yes** | **✅ Fixed in `origin/main`** | **⚪ Code fix only — never deployed** (new modular `bridge_verifier/*` contracts, including `ProcessBridgedDataArbitrum`, are not in `globals_mainnet.json`; `deploy_26_03_*` script has not been run on mainnet yet — bundled with pending GuardCM / GovernorOLAS deployment, §5.4) | this repo: [`4fd7d98`](https://github.com/valory-xyz/autonolas-governance/commit/4fd7d9896332c3cc5b00de8d67f402cb70c154f9), PR [#185](https://github.com/valory-xyz/autonolas-governance/pull/185); code-level verification in §4.1 |
+| [S-668](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-668)   | M | autonolas-tokenomics | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-tokenomics` — out of scope for this report |
+| [S-763](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-763)   | M | autonolas-registries | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-registries` — out of scope for this report |
+| [S-885](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-885)   | M | autonolas-registries | No | 🔴 Not fixed (open) | — (N/A) | Tracked in `autonolas-registries` — out of scope for this report |
+| [S-1030](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1030) | M | autonolas-tokenomics | No | 📝 Documented (known issue) | — (N/A) | Listed in `autonolas-tokenomics` vulnerabilities-list (S-1030) |
+| [S-1045](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1045) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`0948e8b`](https://github.com/valory-xyz/autonolas-tokenomics/commit/0948e8b) |
+| [S-1052](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1052) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`33468a4`](https://github.com/valory-xyz/autonolas-tokenomics/commit/33468a4) |
+| [S-1110](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1110) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`ca9203a`](https://github.com/valory-xyz/autonolas-tokenomics/commit/ca9203a) |
+| [S-1231](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1231) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`ca9203a`](https://github.com/valory-xyz/autonolas-tokenomics/commit/ca9203a) |
+| [S-1266](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1266) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`0948e8b`](https://github.com/valory-xyz/autonolas-tokenomics/commit/0948e8b) |
+| [S-1279](https://code4rena.com/evaluate/j3PRAMM3fVq/submissions/S-1279) | M | autonolas-tokenomics | No | 🟢 Fixed on `fix_oracle_v2` | Not verified here (branch not merged to `origin/main`) | [`33468a4`](https://github.com/valory-xyz/autonolas-tokenomics/commit/33468a4) |
+
+**Per-repo split (H + M) by code status:**
+
+| Repo | Total | ✅ Fixed in `origin/main` | 🟢 Fixed on feature branch | 🟠 Partially fixed | 📝 Documented | 🔴 Not fixed |
+|---|---|---|---|---|---|---|
+| autonolas-governance | **1** | **1 (S-629 / M-01)** | 0 | 0 | 0 | 0 |
+| autonolas-registries | 7 | 1 (S-578) | 0 | 1 (S-1187) | 0 | 5 (S-229, S-858, S-862, S-763, S-885) |
+| autonolas-tokenomics | 15 | 0 | 11 | 0 | 1 (S-1030) | 3 (S-347, S-471, S-668) |
+| **Total** | **23** | **2** | **11** | **1** | **1** | **8** |
+
+**Per-repo split (H + M) by deployment status — only what this report verified:**
+
+| Repo | Verified deployment status | Notes |
+|---|---|---|
+| autonolas-governance | ⚪ Code fix — never deployed (1 of 1) | S-629 fix lives in code; the new modular `bridge_verifier/*` contracts are not in `globals_mainnet.json` and `deploy_26_03_*` has not been run on mainnet yet. Bundled with pending GuardCM / GovernorOLAS deployment (§5.4). |
+| autonolas-registries | Not verified here (7 of 7) | Deployment of `origin/main` registries fixes is not in scope for this report. See `autonolas-registries` audit handoff. |
+| autonolas-tokenomics | Not verified here (15 of 15) | Of these, 11 fixes are on `fix_oracle_v2` which **is not merged to `origin/main`** as of 2026-04-10 — so those 11 are at least *Pending merge* before they could be considered for deployment. See `autonolas-tokenomics` audit handoff. |
+
+**Key disposition for governance-scope:** the only governance-scope finding is **S-629 (= M-01)**: code is **fixed in `origin/main`**; on-chain status is **code fix only — never deployed**. Code-level fix verification in §4.1; deployment-state verification in §5.4 (the same pending redeploy that closes the `governorDelay`/`minDelay` gap closes the M-01 fix's deployment gap, in a single coordinated rollout).
+
+**All other 22 H + M findings (11H + 11M) target `autonolas-tokenomics` or `autonolas-registries`.** Their code-level disposition is shown above; their on-chain liveness is **not verified by this report** and is the responsibility of those two repos' audit handoffs and vulnerabilities-list documents. None of them touch any contract in `autonolas-governance` — verified by repo classification on the C4A submission and confirmed by reading the corresponding source files.
+
+### 4.0.1 Lows (n = 15) — disposition
+
+The 15 Low findings from the C4A 2026-01 report were **not individually enumerated** in the filtered status snapshot used as input here (`full_report_2026-01-olas.md` was filtered to `severity = high|medium` for the H/M handoff round). Per the per-submission repo classification we ran during C4A triage, **none of the 15 Lows landed on a governance-repo contract** — they cluster in `autonolas-tokenomics` (oracle / liquidity-manager paths) and `autonolas-registries` (staking / service-manager paths), and are tracked under those repos' Low-severity handoffs.
+
+**Honest gap-disclosure:** if a future hygiene pass requires per-ID rows for the 15 Lows in this matrix (with S-IDs, summaries, and current statuses), the C4A submissions index for the 2026-01 contest is the source of truth and the snapshot would need to be re-imported with the severity filter relaxed. The aggregate claim "0 Lows are governance-scope" stands on the repo classification we performed; the per-row enumeration does not appear in this document because it never entered the input snapshot we worked from.
+
+**Disposition summary (Lows):** 0 governance-scope, 15 tracked in `autonolas-tokenomics` / `autonolas-registries` (per-ID details in those repos' audit handoffs).
+
+### 4.0.2 What this matrix does and does not assert
+
+To make the scope of this report explicit (so the disposition matrix is not over-read):
+
+- **Asserted in this document:** for the **1** governance-scope finding (S-629 / M-01), both the **code-level fix** (§4.1, on commit `76bda389`) and the **deployment status** (§5.4, on `globals_mainnet.json` 2026-04-21 / `deploy_26_03_*` not yet run) are verified by this report. For the **22** out-of-scope H + M findings (and the **15** Lows), this document only records what we observed in the filtered C4A status snapshot — namely the responsible repo and the snapshot's stated **code-level** status.
+- **Not asserted in this document:** we have **not** performed code-level fix verification, and have **not** performed any deployment / on-chain verification, for the tokenomics or registries findings — that work belongs in those repos' audit handoffs and is out of scope here. Where a row says "Fixed on `fix_oracle_v2`" or "Fixed in `origin/main`" for those two repos, that reflects the C4A snapshot at 2026-04-10, not a re-verification on the current `HEAD` of those repos and not an on-chain check. The deployment column for those rows says **"Not verified here"** to make this honest.
+- **The "Code status" and "Deployment status" columns are independent.** A finding can be code-fixed and not yet live (the case for S-629 / M-01 — the modular `bridge_verifier/*` pattern has never been deployed to mainnet); or code-fixed and live (the typical case once a redeploy happens); or accepted as a known issue with no code change at all. Conflating these two dimensions into a single "FIXED / NOT FIXED" status is exactly what the prior matrix version did and what this split is meant to fix.
+- **No C4A finding is silently dropped.** Every H + M ID appears in the matrix above, classified into governance-scope vs. out-of-scope, with an explicit code status, a deployment status (or "Not verified here"), and, where applicable, a fix-commit link. The 15 Lows are explicitly disclosed at aggregate level with the gap noted.
 
 ### 4.1 C4A M-01 — Arbitrum bridge unchecked refund / value
 
@@ -85,7 +167,7 @@ All other C4A entries (11H + 11M + 15L + disclosures) target other Olas repos an
 
 **Stale comment fix (internal17 side-observation):** `GuardCM.sol` now rejects `bridgeMediatorL2s[i] == address(0)` in `setBridgeMediatorL1BridgeParams` (line 378) and the misleading Arbitrum-specific comment has been removed.
 
-✅ **C4A M-01 — FIXED AND VERIFIED.** No governance-scope C4A finding remains open.
+✅ **C4A M-01 — code fix verified at the source level.** ⚪ **Not yet deployed to mainnet** — the new modular `bridge_verifier/*` contracts (including `ProcessBridgedDataArbitrum`) are absent from `globals_mainnet.json`, and `deploy_26_03_process_bridged_data_arbitrum.sh` has not been run; the fix lands on-chain together with the pending GuardCM / GovernorOLAS deployment described in §5.4. **No governance-scope C4A finding remains open in source code.** The deployment-side closure is gated on the same audit sign-off + redeploy that closes §5.4's `governorDelay` / `minDelay` gap.
 
 ## 5. On-chain verification (Ethereum mainnet, block-tip 2026-04-21)
 
@@ -267,20 +349,34 @@ All internal18 findings were re-verified against HEAD `76bda389`:
 |---|---|
 | Low — `removeNominee` slope drift (extends Vulnerabilities_list #8) | **Will NOT be fixed** — same reasoning as the N-1 `OwnerOnly` swap: `VoteWeighting` is not upgradeable and we don't redeploy it for non-critical issues. Already captured in `docs/Vulnerabilities_list_governance.md` entry #8 (the slope/`changesSum` drift sub-section was added post-internal18). Operational mitigation (voter cleanup / two-step zero-then-remove) documented there. |
 | Notes — FxPortal `setFxRootTunnel`/`setFxChildTunnel` lack access control during deploy window | Risk window closed (tunnel addresses already set); still "redeploy = re-open" |
-| Notes — `addNomineeEVM` / `addNomineeNonEVM` permissionless | Confirmed; design choice |
+| Notes — `addNomineeEVM` / `addNomineeNonEVM` permissionless | Confirmed; design choice. **Migrated this pass to Vulnerabilities_list entry #14** with the off-chain spam-filter / monitoring guidance and a documented optional code-level cap as a future redeploy lever. |
 | Notes — `OLAS.mint()` silent no-op when inflation cap hit | Confirmed; documented design. **Migrated this pass to Vulnerabilities_list entry #12** for integrator-facing mitigation guidance. |
 | Notes — `governorDelay` ↔ `minDelay` circular desync | Confirmed; see also §5.4 for live-state observation. **Migrated this pass to Vulnerabilities_list entry #13** with documented CM-fast-path break-glass recovery. |
-| Notes — `ProcessBridgedDataWormhole` hardcoded `TIMELOCK` constant | Confirmed; trade-off for compile-time safety |
+| Notes — `ProcessBridgedDataWormhole` hardcoded `TIMELOCK` constant | Confirmed; trade-off for compile-time safety. **Migrated this pass to Vulnerabilities_list entry #15** (redeploy-coupling rule for any future Timelock migration; suggested follow-up to parameterise on next bridge_verifier redeploy). |
 | Notes — Mixed `pragma` across contracts | Confirmed (OLAS/veOLAS/buOLAS `^0.8.15`, wveOLAS/FxGovernorTunnel/HomeMediator `^0.8.19`, GovernorOLAS `^0.8.20`, BridgeMessenger/OptimismMessenger/WormholeMessenger `^0.8.23`, VoteWeighting `^0.8.25`, Burner `^0.8.28`, everything else `^0.8.30`) |
 | Low — `Burner.sol` 0% coverage | **Fixed** — `test/Burner.js` (6 tests) added |
 | Notes — C4A fix revert paths untested | **Fixed** — regression tests added in `test/GuardCM.js` |
-| Notes — `GovernorOLAS` exceeds 24576-byte limit | Noted; already deployed on mainnet |
+| Notes — `GovernorOLAS` exceeds 24576-byte limit | **Fixed in this pass** — reduced `optimizer_runs` from `1,000,000` to `200` in both `foundry.toml` and `hardhat.config.js`. `GovernorOLAS` deployed bytecode goes from **24,936 → 20,479 bytes** (4,097-byte EIP-170 margin). All other governance contracts continue to compile cleanly under the new setting. The contract is now portable to chains that strictly enforce EIP-170. **Treated as a config fix, not a `Vulnerabilities_list_governance.md` entry**, because it is fully resolved at the source-tree level (the next deployment will pick up the new bytecode automatically). Going forward, the EIP-170 size budget is a hard rule — see the per-user memory entry for the flagging policy. |
 
 **No new manual-review finding from the fresh read beyond N-1 above.** The bridge delegatecall storage-layout contract (GuardCM ↔ ProcessBridgedData* both inherit VerifyData → slot 0 is `mapAllowedTargetSelectorChainIds` in both) remains correctly aligned; I traced inheritance for all 5 verifiers.
 
 ## 7. `docs/Vulnerabilities_list_governance.md` hygiene
 
-The document now tracks **13 items** (10 carried forward + 3 added this pass: N-1 OwnerOnly swap, OLAS.mint silent no-op, governorDelay/minDelay desync). All re-verified against HEAD.
+The document now tracks **15 items** (10 carried forward + 5 added this pass: N-1 OwnerOnly swap, OLAS.mint silent no-op, governorDelay/minDelay desync, addNominee permissionless, ProcessBridgedDataWormhole hardcoded TIMELOCK). All re-verified against HEAD.
+
+**Note on the `GovernorOLAS` 24,576-byte size finding (internal18 Note):** this one is **NOT** added to the vulnerabilities list — it has been **fixed at the compiler-config level** by reducing `optimizer_runs` from `1,000,000` to `200` in both `foundry.toml` and `hardhat.config.js`. New `GovernorOLAS` deployed bytecode size: **20,479 bytes** (4,097-byte EIP-170 margin). The next deployment of `GovernorOLAS` (§5.4) picks up this smaller bytecode automatically. Going forward, **any contract being modified or queued for deployment must stay under the 24,576-byte EIP-170 limit, and a violation is flagged immediately** — captured as a durable rule in agent memory rather than a vulnerability.
+
+> **Disambiguation — the 5 entries added this pass are NOT unresolved C4A 2026-01 findings.** Per §4, the only governance-scope C4A finding is **S-629 / M-01**, and it is **fixed** on `origin/main` (verified at code level in §4.1). It is therefore deliberately **not** added to `Vulnerabilities_list_governance.md` (which is reserved for *deliberately-unfixed* trade-offs). The five new entries below come from the **internal review track**:
+>
+> - **#11 — `OwnerOnly` revert-data arg order:** finding **N-1**, originated in this internal19 pass (§6.2). Cosmetic-only, will not be fixed (no redeploy of `VoteWeighting` for non-critical issues).
+> - **#12 — `OLAS.mint` silent no-op on inflation cap:** carry-over from **internal18 Notes**, migrated into the formal vulnerabilities-list this pass for integrator-facing mitigation guidance (§6.3 row).
+> - **#13 — `governorDelay` ↔ `minDelay` desync:** carry-over from **internal18 Notes**, migrated into the formal vulnerabilities-list this pass with the documented CM-fast-path break-glass recovery (§6.3 row, see also §5.4).
+> - **#14 — `addNomineeEVM` / `addNomineeNonEVM` permissionless:** carry-over from **internal18 Notes**, migrated this pass with off-chain spam-filter / monitoring guidance and an optional code-level cap as a future redeploy lever.
+> - **#15 — `ProcessBridgedDataWormhole` hardcoded `TIMELOCK` constant:** carry-over from **internal18 Notes**, migrated this pass with the redeploy-coupling rule (Timelock redeploy ⇒ Wormhole verifier redeploy) and a suggested parameterisation follow-up bundled with the next bridge_verifier redeploy.
+>
+> Separately, the **`GovernorOLAS` 24,576-byte size note (internal18)** was **fixed at the compiler-config level** in this pass (`optimizer_runs` 1M → 200) and is therefore **not** in the vulnerabilities list — see the §6.3 row.
+>
+> No C4A 2026-01 finding — H, M, or L — is recorded in `Vulnerabilities_list_governance.md` as "accepted" or "known issue" by this pass, because no C4A 2026-01 finding has that disposition for the governance repo (the single governance-scope item, S-629 / M-01, was fixed in code).
 
 | # | Title | Severity | Code still present? | Mitigation in place? |
 |---|---|---|---|---|
@@ -297,12 +393,15 @@ The document now tracks **13 items** (10 carried forward + 3 added this pass: N-
 | 11 | **`removeNominee` `OwnerOnly` revert-data arg order (NEW — N-1)** | **Informative** | ✅ yes | tooling-side: decode revert as `(owner, sender)` for this call site |
 | 12 | **OLAS `mint` silent no-op on inflation cap (NEW — migrated from internal18)** | **Informative** | ✅ yes | integrators: pre-check `inflationControl`/`inflationRemainder` or verify balance delta, do not assume revert-on-failure |
 | 13 | **`governorDelay` vs timelock `minDelay` desync (NEW — migrated from internal18)** | **Informative** | ✅ yes | always update `minDelay` and `governorDelay` in same proposal; CM fast-path `updateDelay` is break-glass recovery |
+| 14 | **`addNomineeEVM`/`addNomineeNonEVM` permissionless (NEW — migrated from internal18)** | **Informative** | ✅ yes | UI spam filter + off-chain `AddNomineeHash` rate alerts; owner-side periodic cleanup; optional code-level cap on `setNominees.length` as a future redeploy lever |
+| 15 | **`ProcessBridgedDataWormhole` hardcoded `TIMELOCK` (NEW — migrated from internal18)** | **Informative** | ✅ yes | Timelock-redeploy runbook must redeploy + re-wire Wormhole verifier; consider parameterising on the next bridge_verifier redeploy |
 
 **Hygiene status.**
 
 - Entry #8 includes the slope / `changesSum` drift sub-finding from internal18 (potential `oldSum - oldWeight` underflow DoS), with full scenario and operational workarounds.
 - **Entry #11 added in this pass** for the N-1 `OwnerOnly` swapped-args revert in `VoteWeighting.removeNominee`.
-- **Entries #12 and #13 added in this pass** — migrated from the internal18 "Notes" section into the formal list, since both are deliberately-unfixed trade-offs with live operational implications (integrator misuse for #12, governance bricking recovery for #13). This brings the formal list into alignment with the README-level audit findings; future audits can treat this document as the single record of truth for deliberately-unfixed governance-repo trade-offs.
+- **Entries #12 and #13 added in this pass** — migrated from the internal18 "Notes" section into the formal list, since both are deliberately-unfixed trade-offs with live operational implications (integrator misuse for #12, governance bricking recovery for #13).
+- **Entries #14 and #15 added in this pass** — also migrated from internal18 "Notes": #14 captures the permissionless `addNominee*` griefing surface and the recommended off-chain-only mitigation pattern; #15 captures the Wormhole-verifier ↔ Timelock redeploy-coupling rule. With these two additions the doc now covers every internal18 deliberately-unfixed Note that has operational/security implications. Internal18 Notes that did **not** make the list are: mixed pragma versions (style only), and `GovernorOLAS` ≥ 24,576 bytes (resolved at compiler-config level this pass, see §6.3 row + the EIP-170 size-budget rule captured in agent memory).
 
 **Nothing has been removed** from the list — all previously listed items still describe live code paths.
 
@@ -310,15 +409,16 @@ The document now tracks **13 items** (10 carried forward + 3 added this pass: N-
 
 ## 8. Conclusion
 
-- **C4A M-01** (the one governance-scope external finding) — **FIXED** and verified on code (§4.1).
+- **C4A 2026-01 disposition (§4)** — full per-finding matrix recorded for all **23 H + M** items (11H + 12M); **15 Lows** disclosed at aggregate level with the gap noted. The matrix uses two orthogonal status columns — **Code** (fixed in main / fixed on feature branch / partial / documented / not fixed) and **Deployment** (live on-chain / pending redeploy / never deployed / N/A / not verified here) — to avoid conflating "fix exists in source" with "fix is on-chain". Of the 23 H + M, exactly **1 is governance-scope**: **S-629 / M-01** (Arbitrum bridge refund/value verification): **Code = ✅ Fixed in `origin/main`** (commit [`4fd7d98`](https://github.com/valory-xyz/autonolas-governance/commit/4fd7d9896332c3cc5b00de8d67f402cb70c154f9), code-level verification in §4.1); **Deployment = ⚪ Code fix only — never deployed** (modular `bridge_verifier/*` contracts not in `globals_mainnet.json`, bundled with pending GuardCM / GovernorOLAS deployment in §5.4). The other 22 H + M and all 15 Lows target `autonolas-tokenomics` or `autonolas-registries` and are tracked in those repos' audit handoffs; none are governance-scope. **No C4A 2026-01 finding is added to `Vulnerabilities_list_governance.md`** (the file is reserved for governance-repo deliberately-unfixed trade-offs, and S-629 / M-01 was fixed in code).
 - **On-chain owner map (§5)** — all governance contracts resolve to the Timelock; no EOA-owned admin (no Kelp-pattern exposure). CM Safe 5/9 healthy.
 - **Deployed vs. repo delta (§5.4)** — the new `governorDelay` field is not yet deployed on the live Governor; when it is, the effective delay goes from 0 s to 43.6 h (setting in `globals_mainnet.json`). **Resolution: new `GovernorOLAS` to be deployed ASAP after this audit round is signed off.** Not a code bug.
 - **CM Safe has `PROPOSER_ROLE` + `EXECUTOR_ROLE`** on the Timelock, with `minDelay = 0` (§5.5) — **setup is correct by design.** The real access-control layer for CM is the Gnosis Safe `GuardCM` guard, which restricts every `scheduleBatch` payload to the governance-curated allowlist `mapAllowedTargetSelectorChainIds`. That allowlist can only be expanded by a Governor vote (`setTargetSelectorChainIds` is Timelock-only). Within the allowlist, CM acts unilaterally — providing a sub-minute operational fast path for bridge messages, module pauses, etc., demonstrated live on 2026-01-21 in two mainnet txs. The Governor redeployment (§5.4) does not close this path (and is not meant to); `governorDelay` applies only to Governor-originated proposals. Residual opsec item: periodically review `mapAllowedTargetSelectorChainIds` contents for anything that shouldn't be in a sub-minute CM lane.
 - **New code findings this pass:** 1 cosmetic (N-1, `OwnerOnly` args swapped in `removeNominee`). **Resolution: will NOT be fixed in code — added as entry #11 in `Vulnerabilities_list_governance.md`, since `VoteWeighting` is not redeployed for non-critical issues.**
 - **Internal18 findings:** all re-verified; Low on Burner coverage and Notes on C4A-fix test gaps are marked Fixed; `removeNominee` slope drift carry-over Low **will NOT be fixed** (same reasoning as N-1 — covered by Vulnerabilities_list entry #8); the rest are unchanged and operationally accepted.
-- **`Vulnerabilities_list_governance.md`** — now 13 entries (10 carried forward + #11 N-1 + #12 OLAS.mint silent no-op + #13 governorDelay/minDelay desync). Entry #8 already extended with the slope/`changesSum` drift sub-finding. Entries #12 and #13 migrated from internal18 "Notes" so the formal doc now covers every deliberately-unfixed trade-off with operational mitigations.
+- **`Vulnerabilities_list_governance.md`** — now 15 entries (10 carried forward + #11 N-1 OwnerOnly + #12 OLAS.mint silent no-op + #13 governorDelay/minDelay desync + #14 addNominee permissionless + #15 ProcessBridgedDataWormhole hardcoded TIMELOCK). Entry #8 already extended with the slope/`changesSum` drift sub-finding. Entries #12–#15 migrated from internal18 "Notes" so the formal doc now covers every deliberately-unfixed governance-repo trade-off with operational mitigations. **None of the 5 newly added entries are C4A 2026-01 findings** — they are internal-review findings (one originated in this pass, four carried over from internal18). See §7 disambiguation note.
+- **EIP-170 size budget** — internal18's `GovernorOLAS > 24,576 bytes` Note is **fixed at the compiler-config level** this pass: `optimizer_runs` reduced from `1,000,000` to `200` in both `foundry.toml` and `hardhat.config.js`; `GovernorOLAS` deployed bytecode goes from 24,936 → **20,479 bytes** (4,097-byte EIP-170 margin). Going forward, **any contract being modified or queued for deployment must stay under 24,576 bytes, with violations flagged immediately** — captured as a durable agent-memory rule.
 
-**Verdict: no High / Medium / exploitable-Low findings in the governance repo on commit `76bda389`.** The C4A external audit closed the only serious governance issue (Arbitrum bridge refund drain). All remaining items are either (a) closed by the pending `GovernorOLAS` redeployment, (b) permanent Vulnerabilities-list entries tracking deliberately-unfixed trade-offs in `VoteWeighting`, or (c) well-understood inherited Curve behaviour and operational discipline items.
+**Verdict: no High / Medium / exploitable-Low findings in the governance repo on commit `76bda389`.** The C4A external audit identified one governance-scope issue (Arbitrum bridge refund drain) and **the fix is in `origin/main`**; the **on-chain closure** of that finding lands together with the pending GuardCM / GovernorOLAS deployment (§5.4) — they are bundled because the new modular `bridge_verifier/*` contracts are wired in via the new GuardCM. All remaining items are either (a) closed by the pending governance redeployment (covering both the M-01 fix's deployment and the `governorDelay`/`minDelay` gap), (b) permanent Vulnerabilities-list entries tracking deliberately-unfixed trade-offs in `VoteWeighting`, or (c) well-understood inherited Curve behaviour and operational discipline items.
 
 ## 9. Methodology Compliance Report (AGENT-RULES.md)
 

--- a/docs/Vulnerabilities_list_governance.md
+++ b/docs/Vulnerabilities_list_governance.md
@@ -17,6 +17,8 @@
 | 11 | [removeNominee OwnerOnly revert-data argument order](#11-removenominee-owneronly-revert-data-argument-order) | Informative |
 | 12 | [OLAS mint silent no-op on inflation cap](#12-olas-mint-silent-no-op-on-inflation-cap) | Informative |
 | 13 | [governorDelay and timelock minDelay desynchronization](#13-governordelay-and-timelock-mindelay-desynchronization) | Informative |
+| 14 | [VoteWeighting addNomineeEVM and addNomineeNonEVM are permissionless](#14-voteweighting-addnomineeevm-and-addnomineenonevm-are-permissionless) | Informative |
+| 15 | [ProcessBridgedDataWormhole hardcoded TIMELOCK constant](#15-processbridgeddatawormhole-hardcoded-timelock-constant) | Informative |
 
 ## Involved contracts and level of the bugs
 
@@ -598,6 +600,63 @@ discipline — always update both in the same proposal — is the accepted mitig
 3. **Keep `Timelock.updateDelay` in the `GuardCM` allowlist** so the CM fast path
    remains available as a break-glass recovery lane if the constraint is violated
    despite the above.
+
+### 14. `VoteWeighting` `addNomineeEVM` and `addNomineeNonEVM` are permissionless
+
+**Severity:** Informative
+
+In the `VoteWeighting` contract, the following two functions are externally callable by anyone, with no access control:
+
+```solidity
+function addNomineeEVM(address account, uint256 chainId) external
+function addNomineeNonEVM(bytes32 account, uint256 chainId) external
+```
+
+This differs from the upstream Curve `GaugeController.add_gauge` design, which is admin-only. In Olas the asymmetry is intentional: anyone can register a nominee (a service / agent / target on some chain), while only `veOLAS` holders can direct emissions via `voteForNomineeWeights`, and only the contract `owner` (the Timelock) can remove nominees via `removeNominee`.
+
+**Impact / griefing surface.**
+
+- **Unbounded array growth.** Each successful add appends to the `setNominees` array. The array only ever shrinks via owner-driven `removeNominee`. An attacker can register an arbitrary number of distinct nominees (each `(account, chainId)` pair must be unique, but the attacker can vary either field freely), inflating `setNominees.length` and increasing the cost of any iteration over it.
+- **`IDispenser.addNominee` side-effects.** Each `addNominee*` call also invokes `IDispenser.addNominee()` if a Dispenser is configured, which may cause state changes in the Dispenser contract (cost paid by the attacker on L1 gas, but persistent on the Dispenser side).
+- **Misleading nominees.** An attacker can register nominees with names / chain-ids designed to confuse front-end users into voting for the wrong target. The attacker does not gain emissions directly (those still require `veOLAS` voters to allocate weight), but social-engineering attacks on the voter UI become easier.
+
+The practical economic impact is bounded: emissions still require veOLAS voting power, and the asymmetric add-vs-remove cost favours the defender (each spam entry costs the attacker L1 gas; the owner can batch-remove). However, a passive accumulation of spam over months / years would impose a real ops burden.
+
+**Why this is not fixed.** Permissionless add is a deliberate design choice — gating it behind owner-only would add a governance step to every legitimate new nominee, which would slow down the operational cadence of the protocol. The trade-off is "open and slightly griefable" vs. "gated and slow". The Olas design picks the former.
+
+**Mitigation / guidance for operators.**
+
+1. **Off-chain spam filter on the voter UI.** Front-ends that surface the nominee list should filter / rank entries (e.g., by whether the nominee has received any non-attacker votes, or by `(account, chainId)` allowlist), so spam nominees are not equally visible alongside legitimate ones.
+2. **Off-chain monitoring of `AddNomineeHash` event volume.** Set an alert on unusual rate of nominee additions. A sudden burst is the cheap signal of a griefing campaign and triggers the cleanup path below.
+3. **Periodic owner cleanup.** When spam is detected, the owner (Timelock) can `removeNominee` the spam entries. Note that `removeNominee` orphans voting power (entry #8) and has the slope-drift side-effect (entry #8 sub-finding) — the cleanup should be scheduled rather than reactive, and combined with voter cleanup as described in #8.
+4. **Optional code-level cap.** If griefing becomes a sustained problem, a future redeploy could add `if (setNominees.length >= MAX_NOMINEES) revert TooManyNominees();` at the top of `_addNominee`. This is not necessary today.
+
+### 15. `ProcessBridgedDataWormhole` hardcoded `TIMELOCK` constant
+
+**Severity:** Informative
+
+In `ProcessBridgedDataWormhole`, the L1 Timelock address that bridge payloads are required to refund to is a compile-time constant:
+
+```solidity
+address public constant TIMELOCK = 0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE;
+```
+
+The verifier rejects payloads whose `refundAddress != TIMELOCK` and whose `refundChainId != REFUND_CHAIN_ID` (= `2`, Ethereum mainnet in Wormhole chain-id space). This is the correct fix for the C4A 2026-01 Arbitrum-class refund-redirection issue (see internal audit 19 §4.1) — but it bakes the Timelock address into the bytecode of `ProcessBridgedDataWormhole`.
+
+This is **inconsistent with the Arbitrum verifier** (`ProcessBridgedDataArbitrum`), which receives the L2 Timelock equivalent as a parameter via `GuardCM.mapBridgeMediatorL1BridgeParams[target].bridgeMediatorL2`. The Arbitrum approach is more flexible — replacing the L2 mediator is a governance call to `setBridgeMediatorL1BridgeParams`, no redeploy required. The Wormhole approach traps the L1 Timelock address in immutable code.
+
+**Impact.**
+
+- **Timelock redeployment forces verifier redeployment.** If the Olas L1 Timelock is ever redeployed (governance migration, security incident, role-rotation that requires fresh contract), every `ProcessBridgedDataWormhole` instance must be redeployed and re-wired into `GuardCM.mapBridgeMediatorL1BridgeParams` for every Wormhole-bridged target. Forgetting to redeploy the verifier would silently break Wormhole-bridged governance (every payload would revert at the `refundAddress != TIMELOCK` check).
+- **No on-chain mutability.** Unlike the Arbitrum case, there is no governance-side knob to retarget the verifier — the constant is immutable.
+
+**Why this is not fixed.** The hardcoded constant gives compile-time safety: there is no setter to mis-configure, no allowlist row to forget to populate. For the current deployment (one Timelock, no migration on the roadmap), the rigidity is a feature, not a bug. Parameterising it would re-introduce the operational surface that the Arbitrum verifier already has.
+
+**Mitigation / guidance for operators.**
+
+1. **Capture the redeploy-coupling rule in any Timelock-redeploy runbook.** Specifically: "If `Timelock` is redeployed, then every `ProcessBridgedDataWormhole` deployment must also be redeployed at the same time, and `GuardCM.setBridgeMediatorL1BridgeParams` must be re-called for every Wormhole target with the new verifier address."
+2. **On the next bridge-verifier redeploy** (the upcoming one bundled with the C4A M-01 fix and the new `GovernorOLAS`, see internal audit 19 §5.4), consider parameterising the L1 Timelock address the same way the Arbitrum verifier parameterises the L2 mediator. This is a one-time refactor that aligns the two verifier shapes and removes this redeploy-coupling. Not required to land the M-01 fix; can be a follow-up.
+3. **Until then**, treat the Wormhole verifier address as a satellite of the Timelock address — they move together or not at all.
 
 [^1]: The level of the bug is assigned by following the [Immunefi classification](https://immunefi.com/).
 [^2]: Since no manipulation of governance voting can currently happen, this vulnerability identifies a smart contract that fails to deliver promised returns but doesn't lose value.

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = "out"
 test = "test/forge"
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 1000000
+optimizer_runs = 200
 evm_version = "prague"
 
 remappings = [

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -249,7 +249,7 @@ module.exports = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 1000000,
+                        runs: 200,
                     },
                     evmVersion: "prague"
                 },


### PR DESCRIPTION
## Summary

Three changes, all driven by post-review feedback on internal audit 19:

- **C4A 2026-01 disposition matrix (`audits/internal19/README.md`).** Adds a full per-finding matrix for all 11H + 12M C4A items with the 15 Lows disclosed at aggregate level, addressing the colleague feedback that the previous version only documented `M-01` and left the disposition of the remaining 22 H + M findings ambiguous. The matrix splits status into two orthogonal columns — **Code status** (fixed in `origin/main` / fixed on feature branch / partial / documented / not fixed) and **Deployment status** (live on-chain / pending redeploy / never deployed / N/A / not verified here) — so source-tree fixes are not conflated with on-chain liveness. The only governance-scope row, S-629 / M-01, is now correctly recorded as **Code = ✅ Fixed in `origin/main`** but **Deployment = ⚪ Code fix only — never deployed** (the new modular `bridge_verifier/*` contracts are absent from `globals_mainnet.json` and land on-chain together with the pending GuardCM / GovernorOLAS redeploy described in §5.4).
- **Two new vulnerabilities-list entries (`docs/Vulnerabilities_list_governance.md`).** Both migrated from internal18 Notes:
  - **#14** — `VoteWeighting.addNomineeEVM` / `addNomineeNonEVM` are permissionless (asymmetric add-vs-remove griefing surface; off-chain spam-filter / monitoring guidance + optional code-level cap as a future redeploy lever).
  - **#15** — `ProcessBridgedDataWormhole` hardcoded `TIMELOCK` constant (redeploy-coupling rule for any future Timelock migration; suggested parameterisation follow-up bundled with the next bridge_verifier redeploy). Neither is a C4A 2026-01 finding — both are deliberately-unfixed governance-repo trade-offs being formalised so future audits can treat the doc as the single record of truth.
- **EIP-170 fix (`foundry.toml`, `hardhat.config.js`).** Reduce `optimizer_runs` from `1,000,000` to `200`. `GovernorOLAS` deployed bytecode goes from **24,936 → 20,479 bytes**, giving a 4,097-byte EIP-170 margin and unblocking deployability on chains that strictly enforce EIP-170. This closes internal18's "GovernorOLAS exceeds 24,576-byte limit" Note at the compiler-config level — no contract source change required.

The vulnerabilities list now tracks 15 entries (10 carried forward + #11–#15 added across this audit cycle). None of the 5 newly-added entries are C4A 2026-01 items.

## Test plan

- [x] `forge build --sizes` shows `GovernorOLAS` runtime size = 20,479 B (4,097 B EIP-170 margin); `GuardCM` 8,331 B; `VoteWeighting` 10,335 B; `WormholeRelayerTimelock` 3,223 B — all comfortably under 24,576 B.
- [x] `npx hardhat compile` succeeds at `runs = 200` with the same warnings as before (one stale `view`-mutability suggestion in `wveOLAS.sol:328`, pre-existing).
- [x] `npx hardhat test test/Burner.js` — 6 passing under the new optimizer setting.
- [ ] Reviewer to spot-check a Solidity-side critical path (e.g. `npx hardhat test test/GovernorOLAS.js` or the full suite) to confirm no behaviour regression from the runs change. Lower runs trades a small amount of per-call gas for bytecode size; we don't expect any functional change.
- [ ] Reviewer to confirm the M-01 deployment-status claim — the new modular `bridge_verifier/*` contracts (including `ProcessBridgedDataArbitrum` with the M-01 fix) and the new `GuardCM` / `GovernorOLAS` are correctly grouped under the same upcoming deployment, and the pending deploy-script set (`deploy_26_*`, `script_26_*_set_bridge_mediators_*`) covers the full rotation.
- [ ] Reviewer to confirm vocabulary in the disposition matrix (Code-status / Deployment-status enums) reads cleanly to an external reader.