### PR TITLE
doc: update CHANGELOG for v1.2.5-post-external-audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Common Changelog](https://common-changelog.org).
 
+[1.2.5-post-external-audit]: https://github.com/valory-xyz/autonolas-governance/compare/v1.2.3...v1.2.5-post-external-audit
 [1.2.3]: https://github.com/valory-xyz/autonolas-governance/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/valory-xyz/autonolas-governance/compare/v1.1.10...v1.2.2
 [1.1.10]: https://github.com/valory-xyz/autonolas-governance/compare/v1.1.9...v1.1.10
@@ -18,6 +19,19 @@ The format is based on [Common Changelog](https://common-changelog.org).
 [1.1.1]: https://github.com/valory-xyz/autonolas-governance/compare/v1.0.1...v1.1.1
 [1.0.1]: https://github.com/valory-xyz/autonolas-governance/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/valory-xyz/autonolas-governance/releases/tag/v1.0.0
+
+## [v1.2.5-post-external-audit] - 2026-05-07
+- Separated `Timelock` and `GovernorOLAS` execution delays ([#178](https://github.com/valory-xyz/autonolas-governance/pull/178)) with the subsequent internal audit ([audit15](https://github.com/valory-xyz/autonolas-governance/tree/main/audits/internal15) via [#179](https://github.com/valory-xyz/autonolas-governance/pull/179))
+- Refactored `WormholeRelayerTimelock` to handle token-amount transfers ([#180](https://github.com/valory-xyz/autonolas-governance/pull/180)) with the subsequent internal audit ([audit16](https://github.com/valory-xyz/autonolas-governance/tree/main/audits/internal16) via [#181](https://github.com/valory-xyz/autonolas-governance/pull/181))
+- Added `create_l2_op_olas` script for Optimism L2 OLAS deployment ([#183](https://github.com/valory-xyz/autonolas-governance/pull/183))
+- Static audit pass and ownership CSV ([#184](https://github.com/valory-xyz/autonolas-governance/pull/184))
+- Participated in the [Code4rena 2026-01](https://code4rena.com/evaluate/j3PRAMM3fVq) external audit (C4A) and addressed the single governance-scope finding (M-01): `ProcessBridgedDataArbitrum` and `ProcessBridgedDataWormhole` now validate retryable-ticket refund/value parameters and reject non-Timelock recipients ([#185](https://github.com/valory-xyz/autonolas-governance/pull/185), [#186](https://github.com/valory-xyz/autonolas-governance/pull/186), [#190](https://github.com/valory-xyz/autonolas-governance/pull/190), [#192](https://github.com/valory-xyz/autonolas-governance/pull/192))
+- Internal audits verifying the C4A fixes and re-checking governance-scope ([audit17](https://github.com/valory-xyz/autonolas-governance/tree/main/audits/internal17), [audit18](https://github.com/valory-xyz/autonolas-governance/tree/main/audits/internal18), [audit19](https://github.com/valory-xyz/autonolas-governance/tree/main/audits/internal19) via [#189](https://github.com/valory-xyz/autonolas-governance/pull/189), [#193](https://github.com/valory-xyz/autonolas-governance/pull/193), [#194](https://github.com/valory-xyz/autonolas-governance/pull/194), [#195](https://github.com/valory-xyz/autonolas-governance/pull/195))
+- Restored EIP-170 compliance in `GuardCM` after the audit-driven changes ([#195](https://github.com/valory-xyz/autonolas-governance/pull/195))
+- Added Forge deployment scripts for `GuardCM`, the `ProcessBridgedData{Arbitrum,Gnosis,Optimism,Polygon}` bridge verifiers (`deploy_26_*`) and `GovernorOLAS` (`deploy_27_*`), plus matching `setBridgeMediatorL1BridgeParams` configuration scripts ([#187](https://github.com/valory-xyz/autonolas-governance/pull/187))
+- Added `ForkDeployGovernance` Forge fork test validating the deployment scripts against mainnet state ([#187](https://github.com/valory-xyz/autonolas-governance/pull/187))
+- Migrated `Vulnerabilities_list_governance` from PDF to markdown with relative links ([#191](https://github.com/valory-xyz/autonolas-governance/pull/191))
+- Fixed OLAS-on-Celo address in documentation ([#188](https://github.com/valory-xyz/autonolas-governance/pull/188))
 
 ## [v1.2.3] - 2024-11-01
 - Deployed `Burner` contract on ETH mainnet ([#160](https://github.com/valory-xyz/autonolas-governance/pull/160))


### PR DESCRIPTION
## Summary
- Adds a `[v1.2.5-post-external-audit]` entry to `CHANGELOG.md` covering the v1.2.5 cycle — Timelock/Governor delay separation, Wormhole relayer token-amount refactor, Code4rena 2026-01 (C4A) external audit, the M-01 fix in `ProcessBridgedData{Arbitrum,Wormhole}`, internal audits 17/18/19, the GuardCM EIP-170 fix, and the new `deploy_26_*` / `deploy_27_*` Forge scripts.
- Once merged, the existing `v1.2.5-post-external-audit` tag (currently pointing at `b5875317`, before the post-audit fixes) should be force-moved to the merge commit so the tag actually contains the C4A fixes it claims to.

## Test plan
- [ ] `CHANGELOG.md` renders correctly on GitHub (link references, bullet formatting, PR/audit links resolve).
- [ ] After merge, force-move the tag:
  ```
  git fetch origin
  git tag -f v1.2.5-post-external-audit origin/main
  git push origin :refs/tags/v1.2.5-post-external-audit
  git push origin v1.2.5-post-external-audit
  ```
- [ ] Verify `git show v1.2.5-post-external-audit` lands on the merge commit and the changelog entry is present.