### PR TITLE
submodule: add forge-std pinned to v1.9.7 + fix fork-tests setup docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "lib/fx-portal"]
 	path = lib/fx-portal
 	url = https://github.com/0xPolygon/fx-portal
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -109,13 +109,23 @@ Deploy order is load-bearing:
 
 `test/forge/ForkGovernanceVetoDelay.t.sol` is a mainnet-fork verification of the veto
 stack. It (and the pre-existing `ForkDeployGovernance.t.sol`) depend on `forge-std`,
-which is **not** tracked as a submodule in this repo. From a fresh clone:
+which is tracked as a submodule pinned to `v1.9.7` (see `.gitmodules`).
+
+Fresh clone:
 
 ```bash
-# One-time: install forge-std into lib/
-forge install foundry-rs/forge-std --no-commit
+git clone --recursive git@github.com:valory-xyz/autonolas-governance.git
+```
 
-# Run the veto-stack suite (mainnet fork)
+Existing clone that pre-dates the submodule:
+
+```bash
+git submodule update --init --recursive
+```
+
+Then:
+
+```bash
 ETH_RPC_URL=<mainnet-rpc-url> forge test --match-contract ForkGovernanceVetoDelay -vv
 ```
 


### PR DESCRIPTION
## Summary

Previously `forge-std` was not tracked as a submodule, so the fork suite (`ForkGovernanceVetoDelay.t.sol` + the pre-existing `ForkDeployGovernance.t.sol`) could not be run from a fresh clone with `git clone --recursive` alone. The documented setup used `forge install foundry-rs/forge-std --no-commit` — but Foundry `v1.x` dropped the `--no-commit` flag (its behaviour is now the default), so the documented command actually errors out on a fresh install:

```
$ forge install foundry-rs/forge-std --no-commit
error: unexpected argument '--no-commit' found
```

This PR adds `forge-std` as a proper submodule pinned to **`v1.9.7`** (commit `77041d2`) and updates the setup docs.

## Changes

- `.gitmodules` — new `lib/forge-std` submodule entry.
- `lib/forge-std` — pinned to commit `77041d2` (tag `v1.9.7`).
- `scripts/deployment/README.md` — dropped the `forge install` step; new setup is `git clone --recursive` (fresh) or `git submodule update --init --recursive` (existing clone). No more `.gitmodules` diff sneaking into a subsequent `git commit -am` after the deploy scripts run.

## Test plan

- [x] Fresh clone + `git submodule update --init --recursive` populates `lib/forge-std/` at `77041d2`.
- [x] `forge test --match-contract ForkGovernanceVetoDelay` — **12/12 PASS** on live mainnet fork against the pinned v1.9.7.
- [x] `git status` clean after `git submodule update` (no `.gitmodules` drift).