### PR TITLE
docs/test: close internal21 gates (4) and (6); correct the deploy ordering

### DIFF
--- a/audits/internal21/README.md
+++ b/audits/internal21/README.md
@@ -386,6 +386,24 @@ the corrections rather than silently editing.
   correct; only its stated *reason* is corrected (stable proxy address + operational ordering, not
   a zero-VW init).
 
+  > **Superseded 2026-08-13 (post-merge).** The placeholder step above is no longer required.
+  > Tokenomics #314 subsequently landed `cf881af`, which removes the zero check on `_voteWeighting`
+  > in `Dispenser.initialize` precisely to break this cycle, and adds
+  > `scripts/deployment/script_dispenser_change_managers.sh` to do the wiring. The procedure that
+  > actually ships is:
+  >
+  > 1. `deploy_07a_dispenser.sh` — Dispenser implementation;
+  > 2. `deploy_07b_dispenser_proxy.sh` — DispenserProxy, initialised with **`voteWeighting = 0`**
+  >    (the proxy is `StakingIncentivesPaused` by construction, and `addNominee` is unreachable
+  >    while `voteWeighting` is zero, so no claim path can run);
+  > 3. `deploy_23_vote_weighting.sh` — `VoteWeighting(ve, dispenserProxyAddress)`;
+  > 4. `script_dispenser_change_managers.sh` — wires the real Vote Weighting in while still paused;
+  > 5. set deposit processors, then unpause.
+  >
+  > The substance of the correction is unchanged: the Dispenser proxy supplies a **stable address**,
+  > not a broken cycle — the cycle is broken by the zero-VW `initialize` plus the ordering above.
+  > Ship-gate (5) still holds.
+
 - **Item #7 (vuln-doc drift) is NOT resolved — the `70cf7ab` reword left §20 self-contradictory.**
   The verdict listed #7 as resolved. In fact §20's **Status** now reads "the checkpoint-advance fix
   described below is implemented," while the **Fix on redeploy** text immediately below still reads
@@ -408,3 +426,29 @@ enforced; (3) forge → CI; (4) finding-#8 severity ≥ Medium; (5) cross-repo l
 #309/#314; (6) test rename — **plus** these three doc/script corrections: **§20 reword (re-opened #7)**,
 the **deploy-ordering runbook** (the real 3-step, replacing the withdrawn zero-VW claim), and the
 **`verify_23` zero fallback**. None touch the audited accounting.
+
+---
+
+## POST-MERGE 2026-08-13 — gates (4) and (6) closed, deploy ordering corrected
+
+PR #215 merged as `afb00f0`. Three of the residual items were doc/test-only and are now applied
+directly on `main`; the accounting is untouched (`contracts/VoteWeighting.sol` unchanged, forge
+`VoteWeightingTest` 17/17).
+
+- **Gate (4) — finding-#8 severity.** `Vulnerabilities_list_governance.md` §8 raised **Low → Medium**,
+  in both the summary table and the section header, with the rationale recorded inline (the original
+  Low was set against the orphaned-voting-power reading, not the checkpoint-DoS documented in the
+  entry).
+- **Gate (6) — test rename.** `test_RemoveNominee_ExpiredVoter_NoUnderflow` →
+  `test_RemoveNominee_ExpiredVoter_Consistent`, with a `@notice` recording that it is **not** a
+  regression test (it passes on the pre-fix contract) and naming the three that are. References to
+  the old name earlier in this document (§2.2, §"Adjudication") are historical and left as written.
+- **Deploy ordering.** The 3-step procedure in the CORRECTION above is superseded — see the inline
+  "Superseded 2026-08-13" note. Tokenomics #314 (`cf881af`) removed the zero check on
+  `_voteWeighting` in `Dispenser.initialize`, so the shipped order is impl → proxy (VW = 0) →
+  `VoteWeighting(ve, dispenserProxy)` → `script_dispenser_change_managers.sh` → deposit processors →
+  unpause.
+
+**Remaining ship gates, unchanged:** (1) external re-audit adding the #2 revert-repro; (2) drift
+monitor enforced as a launch requirement; (3) forge wired into CI; (5) cross-repo lock with
+tokenomics #309/#314.

--- a/docs/Vulnerabilities_list_governance.md
+++ b/docs/Vulnerabilities_list_governance.md
@@ -11,7 +11,7 @@
 | 5 | [totalSupplyLockedAtT function](#5-totalsupplylockedatt-function) | Low |
 | 6 | [getPastTotalSupply function](#6-getpasttotalsupply-function) | Low |
 | 7 | [processMessageFromForeign function](#7-processmessagefromforeign-function) | Informative |
-| 8 | [removeNominee function](#8-removenominee-function) | Low |
+| 8 | [removeNominee function](#8-removenominee-function) | Medium |
 | 9 | [_addNominee and removeNominee functions](#9-_addnominee-and-removenominee-functions) | Informative |
 | 10 | [voteForNomineeWeights function](#10-voteforNomineeweights-function) | Informative |
 | 11 | [removeNominee OwnerOnly revert-data argument order](#11-removenominee-owneronly-revert-data-argument-order) | Informative |
@@ -278,7 +278,13 @@ incorporating a `chainId` check.
 
 ### 8. `removeNominee` function
 
-**Severity:** Low
+**Severity:** Medium
+
+> Raised from **Low** to **Medium** in the internal21 fix-verification round. The original label
+> was set against the orphaned-voting-power reading of this entry; the accounting defect documented
+> below is a permanent checkpoint DoS — once triggered, the weekly `_getSum()` walk reverts and
+> `nomineeRelativeWeightWrite` (and with it the Dispenser reward-distribution path) halts, with no
+> recovery short of redeployment. Medium reflects that impact.
 
 In the VoteWeighting contract, the following function is implemented:
 

--- a/test/forge/VoteWeighting.t.sol
+++ b/test/forge/VoteWeighting.t.sol
@@ -344,7 +344,14 @@ contract VoteWeightingTest is Test {
 
     /// @dev A voter whose lock already expired (its changesSum decrement was already applied by a
     ///      prior checkpoint) must not cause an underflow or double subtraction on removal.
-    function test_RemoveNominee_ExpiredVoter_NoUnderflow() public {
+    /// @notice NOT a regression test: this case passes on the pre-fix contract too. It is a
+    ///         consistency check on the post-fix reconciliation, kept for coverage of the
+    ///         already-expired-voter path. The regression tests that fail on the pre-fix build are
+    ///         test_RemoveWithoutUnvote_NoCheckpointDoS, test_RemoveNominee_ReconcilesSlopeAndChangesSum
+    ///         and test_RemoveNominee_MultiVoter_FullReconcile. Renamed from
+    ///         test_RemoveNominee_ExpiredVoter_NoUnderflow, whose name implied regression coverage
+    ///         it does not provide.
+    function test_RemoveNominee_ExpiredVoter_Consistent() public {
         _lock(alice, 1_000 ether, 3 * WEEK); // short: will expire before removal
         _lock(carol, 1_000 ether, 200 * WEEK);
 


### PR DESCRIPTION
Post-merge follow-up to #215 (`afb00f0`). **Documentation and test-naming only** — `contracts/VoteWeighting.sol` is untouched (`git diff origin/main -- contracts/` is empty) and `forge test --match-contract VoteWeightingTest` is **17/17**.

Three of internal21's residual items were doc/test-only and did not need to block the merge. This closes them on `main`.

## Changes

### Finding #8 severity: Low → Medium (ship gate 4)

Raised in both the summary table and the section header, with the rationale recorded inline. The original **Low** was set against the orphaned-voting-power reading of the entry; the accounting defect documented in the *same* entry is a permanent checkpoint DoS — once triggered, the weekly `_getSum()` walk reverts and `nomineeRelativeWeightWrite` (and with it the Dispenser reward-distribution path) halts, with no recovery short of redeployment. internal21's own verdict called for at least Medium.

### Test rename (ship gate 6)

`test_RemoveNominee_ExpiredVoter_NoUnderflow` → `test_RemoveNominee_ExpiredVoter_Consistent`, plus a `@notice` recording that it is **not** a regression test — it passes on the pre-fix contract — and naming the three that are (`test_RemoveWithoutUnvote_NoCheckpointDoS`, `test_RemoveNominee_ReconcilesSlopeAndChangesSum`, `test_RemoveNominee_MultiVoter_FullReconcile`). The old name implied regression coverage it does not provide.

### Deploy ordering corrected

internal21's `CORRECTION` prescribed breaking the Dispenser ↔ VoteWeighting cycle with a **placeholder non-zero** `voteWeighting`. That was accurate when written, but tokenomics #314 has since landed `cf881af`, which removes the zero check on `_voteWeighting` in `Dispenser.initialize` specifically to break the cycle, and adds `script_dispenser_change_managers.sh` for the wiring. The order that actually ships:

1. `deploy_07a_dispenser.sh` — implementation
2. `deploy_07b_dispenser_proxy.sh` — proxy, initialised with **`voteWeighting = 0`**
3. `deploy_23_vote_weighting.sh` — `VoteWeighting(ve, dispenserProxyAddress)`
4. `script_dispenser_change_managers.sh` — wires the real Vote Weighting while still paused
5. set deposit processors, then unpause

Recorded as a dated **Superseded** note inline plus a **POST-MERGE** section, rather than rewriting the audit of record. Historical references to the old test name earlier in internal21 are left as written for the same reason.

## Still open

Ship gates **(1)** external re-audit adding the revert-DoS repro, **(2)** the off-chain drift monitor as an enforced launch requirement, **(3)** forge wired into CI, and **(5)** the cross-repo lock with tokenomics #309/#314 remain open and are unaffected by this PR.

## Test plan

- [x] `forge test --match-contract VoteWeightingTest` — 17/17
- [x] `git diff origin/main -- contracts/` empty (no contract change)
- [x] No stale references to the old test name outside the historical audit record
