### PR TITLE
docs(deployment): document the dispenserAddress prerequisite for VoteWeighting

### DIFF
--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -61,6 +61,62 @@ npx hardhat run scripts/deployment/deploy_17_governorTwo.js --network network_ty
 Then, after successful deployment of two supplemental contracts, the last script gives the proposal payload necessary to finalize the deployment:
 `npx hardhat run scripts/deployment/deploy_18_governor_to_governorTwo.js --network network_type`.
 
+## Deployment of VoteWeighting
+
+`VoteWeighting` is an Ethereum **mainnet** contract: it binds `veOLAS` (L1-only) and the L1
+`Dispenser` immutably in its constructor, so it is deployed against `globals_mainnet.json`
+(`chainId` 1) and not on any L2.
+
+### Get into a deployable state
+
+```bash
+git clone --recursive git@github.com:valory-xyz/autonolas-governance.git
+cd autonolas-governance
+yarn
+foundryup
+forge build
+```
+
+Export the original-Etherscan `ETHERSCAN_API_KEY` (used by `forge verify-contract`) and the
+`ALCHEMY_API_KEY_MAINNET` key the script appends to `networkURL`.
+
+### REQUIRED before deploying — refresh `dispenserAddress`
+
+`scripts/deployment/globals_mainnet.json` ships with `dispenserAddress` unset (`null`), and
+`deploy_23_vote_weighting.sh` aborts on a missing/zero value by design. Set it to the current
+live Dispenser address, taken from the [autonolas-tokenomics](https://github.com/valory-xyz/autonolas-tokenomics)
+repo's `scripts/deployment/globals_mainnet.json` key **`dispenserProxyAddress`** — the
+`DispenserProxy`, i.e. the address everything wires to, not the Dispenser implementation.
+
+This has to be re-checked on **every** run: whenever new Dispenser contracts are deployed in
+the tokenomics repo, the proxy address changes, and VoteWeighting stores the dispenser as an
+**immutable** — a stale or wrong address can only be corrected by redeploying VoteWeighting.
+
+```bash
+# in autonolas-governance, with <dispenserProxyAddress> copied from the tokenomics globals
+jq '.dispenserAddress = "<dispenserProxyAddress>"' scripts/deployment/globals_mainnet.json > tmp \
+  && mv tmp scripts/deployment/globals_mainnet.json
+```
+
+### Deploy
+
+```bash
+./scripts/deployment/deploy_23_vote_weighting.sh mainnet
+```
+
+The script deploys `contracts/VoteWeighting.sol`, writes `voteWeightingAddress` back into
+`globals_mainnet.json` (**overwriting** the previous VoteWeighting address), asserts the
+deployed `ve()` / `dispenser()` / `owner()` against the expected values, and verifies the
+contract on Etherscan (plus Blockscout when `blockscoutURL` is set).
+
+### Push back the changes
+
+```bash
+git checkout -b vw_deployment
+git commit -am "chore: deployment of VoteWeighting contract"
+git push origin vw_deployment
+```
+
 ## Deployment of the Veto stack (Task 1)
 
 A cancel-only Veto-Governor bound to a dedicated Veto Timelock. Both contracts are

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -80,23 +80,43 @@ forge build
 Export the original-Etherscan `ETHERSCAN_API_KEY` (used by `forge verify-contract`) and the
 `ALCHEMY_API_KEY_MAINNET` key the script appends to `networkURL`.
 
-### REQUIRED before deploying — refresh `dispenserAddress`
+### REQUIRED before deploying — set `dispenserAddress`
 
-`scripts/deployment/globals_mainnet.json` ships with `dispenserAddress` unset (`null`), and
-`deploy_23_vote_weighting.sh` aborts on a missing/zero value by design. Set it to the current
-live Dispenser address, taken from the [autonolas-tokenomics](https://github.com/valory-xyz/autonolas-tokenomics)
-repo's `scripts/deployment/globals_mainnet.json` key **`dispenserProxyAddress`** — the
-`DispenserProxy`, i.e. the address everything wires to, not the Dispenser implementation.
+`scripts/deployment/globals_mainnet.json` has **no `dispenserAddress` key**, and
+`deploy_23_vote_weighting.sh` aborts on a missing/zero value by design. Add it, set to the
+**current live Dispenser** address from the
+[autonolas-tokenomics](https://github.com/valory-xyz/autonolas-tokenomics) repo's
+`scripts/deployment/globals_<network>.json`.
 
-This has to be re-checked on **every** run: whenever new Dispenser contracts are deployed in
-the tokenomics repo, the proxy address changes, and VoteWeighting stores the dispenser as an
-**immutable** — a stale or wrong address can only be corrected by redeploying VoteWeighting.
+**Which key holds that address depends on whether the proxied-Dispenser migration has happened
+yet** — and the meaning of `dispenserAddress` on the tokenomics side flips at that point:
+
+| State of the tokenomics repo | Live Dispenser = key | Do **not** copy |
+|---|---|---|
+| Before the migration (**today**) | `dispenserAddress` | — (`dispenserProxyAddress` does not exist yet) |
+| After `deploy_07b_dispenser_proxy.sh` has run | `dispenserProxyAddress` (the `DispenserProxy`) | `dispenserAddress` — from then on it is the Dispenser **implementation** |
+
+Copying the implementation address post-migration binds VoteWeighting to a contract with no
+live state, and is only fixable by redeploying VoteWeighting. The cross-repo handoff is
+described from the tokenomics side in its
+[Dispenser migration runbook](https://github.com/valory-xyz/autonolas-tokenomics/blob/main/docs/dispenser_migration_runbook_public.md)
+(step 9 deploys VoteWeighting against the step-8 proxy).
+
+Re-check the value on **every** run: whenever new Dispenser contracts are deployed, the live
+address changes, and VoteWeighting stores the dispenser as an **immutable**.
 
 ```bash
-# in autonolas-governance, with <dispenserProxyAddress> copied from the tokenomics globals
-jq '.dispenserAddress = "<dispenserProxyAddress>"' scripts/deployment/globals_mainnet.json > tmp \
+# in autonolas-governance, with <liveDispenser> copied from the tokenomics globals per the table above
+jq '.dispenserAddress = "<liveDispenser>"' scripts/deployment/globals_mainnet.json > tmp \
   && mv tmp scripts/deployment/globals_mainnet.json
 ```
+
+Before broadcasting, the script pre-flights the address: it must have contract code, and it must
+read a non-zero `owner()` — a bare Dispenser implementation reads `owner() == 0`, because the
+implementation constructor sets immutables only and `initialize()` is delegatecalled by the
+`DispenserProxy` constructor. `voteWeighting()` is printed but not asserted: a freshly deployed
+proxy is initialized with `voteWeighting == 0` on purpose (VoteWeighting does not exist yet — it
+binds the proxy), so it cannot discriminate.
 
 ### Deploy
 
@@ -104,10 +124,12 @@ jq '.dispenserAddress = "<dispenserProxyAddress>"' scripts/deployment/globals_ma
 ./scripts/deployment/deploy_23_vote_weighting.sh mainnet
 ```
 
-The script deploys `contracts/VoteWeighting.sol`, writes `voteWeightingAddress` back into
-`globals_mainnet.json` (**overwriting** the previous VoteWeighting address), asserts the
-deployed `ve()` / `dispenser()` / `owner()` against the expected values, and verifies the
-contract on Etherscan (plus Blockscout when `blockscoutURL` is set).
+The script pre-flights the dispenser (above), deploys `contracts/VoteWeighting.sol`, writes
+`voteWeightingAddress` back into `globals_mainnet.json` (**overwriting** the previous
+VoteWeighting address), asserts the deployed `ve()` / `dispenser()` / `owner()` against the
+expected values, and verifies the contract on Etherscan (plus Blockscout when `blockscoutURL`
+is set). The post-deploy asserts only *report* a wrong immutable — the pre-flight is what can
+still prevent it.
 
 ### Push back the changes
 

--- a/scripts/deployment/deploy_23_vote_weighting.js
+++ b/scripts/deployment/deploy_23_vote_weighting.js
@@ -31,6 +31,9 @@ async function main() {
     // Note: the dispenser is immutable and set at construction; the Dispenser must be deployed beforehand.
     // The contract accepts a zero dispenser to run standalone, but that is NOT this deployment's case:
     // for the tokenomics wiring a zero dispenser would permanently brick the Dispenser link, so refuse it.
+    // dispenserAddress must be refreshed before each run from the autonolas-tokenomics repo globals key
+    // `dispenserProxyAddress` (the DispenserProxy). It changes whenever new Dispenser contracts are
+    // deployed there, and a stale value here can only be corrected by redeploying VoteWeighting.
     const dispenserAddress = parsedData.dispenserAddress;
     if (!dispenserAddress || dispenserAddress === ethers.constants.AddressZero) {
         throw new Error("dispenserAddress is not set (or is the zero address) in " + globalsFile +

--- a/scripts/deployment/deploy_23_vote_weighting.js
+++ b/scripts/deployment/deploy_23_vote_weighting.js
@@ -31,9 +31,10 @@ async function main() {
     // Note: the dispenser is immutable and set at construction; the Dispenser must be deployed beforehand.
     // The contract accepts a zero dispenser to run standalone, but that is NOT this deployment's case:
     // for the tokenomics wiring a zero dispenser would permanently brick the Dispenser link, so refuse it.
-    // dispenserAddress must be refreshed before each run from the autonolas-tokenomics repo globals key
-    // `dispenserProxyAddress` (the DispenserProxy). It changes whenever new Dispenser contracts are
-    // deployed there, and a stale value here can only be corrected by redeploying VoteWeighting.
+    // dispenserAddress must be refreshed before each run from the autonolas-tokenomics globals: it is
+    // the LIVE Dispenser, which is their `dispenserAddress` key before the proxied-Dispenser migration
+    // and their `dispenserProxyAddress` key after it (at which point their `dispenserAddress` means the
+    // implementation and must never be copied here). A wrong value can only be corrected by redeploying.
     const dispenserAddress = parsedData.dispenserAddress;
     if (!dispenserAddress || dispenserAddress === ethers.constants.AddressZero) {
         throw new Error("dispenserAddress is not set (or is the zero address) in " + globalsFile +

--- a/scripts/deployment/deploy_23_vote_weighting.sh
+++ b/scripts/deployment/deploy_23_vote_weighting.sh
@@ -10,7 +10,16 @@
 #                   deployment's case: for the tokenomics wiring a zero here would permanently
 #                   brick the Dispenser link, so a missing/zero dispenserAddress is a hard error.
 #
-# Writes:  globals.voteWeightingAddress
+# PREREQUISITE — refresh globals.dispenserAddress before every run:
+#   globals_<network>.json ships with dispenserAddress unset (null) on purpose. Before deploying,
+#   set it to the CURRENT live Dispenser address taken from the autonolas-tokenomics repo:
+#   its globals_<network>.json key `dispenserProxyAddress` (the DispenserProxy — that proxy, not
+#   the implementation, is the address everything wires to). Whenever new Dispenser contracts are
+#   deployed there, this value changes and MUST be re-copied here before VoteWeighting is deployed:
+#   VoteWeighting binds the dispenser immutably, so a stale address can only be fixed by
+#   redeploying VoteWeighting.
+#
+# Writes:  globals.voteWeightingAddress  (overwrites any previous VoteWeighting address)
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)
@@ -71,6 +80,8 @@ dispenserAddress=$(jq -r '.dispenserAddress' $globals)
 if [ "$dispenserAddress" == "null" ] || [ -z "$dispenserAddress" ] || [ "$dispenserAddress" == "0x0000000000000000000000000000000000000000" ]; then
   echo "${red}!!! dispenserAddress is not set (or is the zero address) in $globals${reset}"
   echo "${red}    VoteWeighting binds the dispenser immutably; refusing to deploy with no dispenser.${reset}"
+  echo "${red}    Copy the current dispenserProxyAddress from the autonolas-tokenomics globals_$1.json${reset}"
+  echo "${red}    into dispenserAddress here, and re-check it after every new Dispenser deployment.${reset}"
   exit 1
 fi
 

--- a/scripts/deployment/deploy_23_vote_weighting.sh
+++ b/scripts/deployment/deploy_23_vote_weighting.sh
@@ -11,13 +11,19 @@
 #                   brick the Dispenser link, so a missing/zero dispenserAddress is a hard error.
 #
 # PREREQUISITE — refresh globals.dispenserAddress before every run:
-#   globals_<network>.json ships with dispenserAddress unset (null) on purpose. Before deploying,
-#   set it to the CURRENT live Dispenser address taken from the autonolas-tokenomics repo:
-#   its globals_<network>.json key `dispenserProxyAddress` (the DispenserProxy — that proxy, not
-#   the implementation, is the address everything wires to). Whenever new Dispenser contracts are
-#   deployed there, this value changes and MUST be re-copied here before VoteWeighting is deployed:
-#   VoteWeighting binds the dispenser immutably, so a stale address can only be fixed by
-#   redeploying VoteWeighting.
+#   globals_<network>.json has no dispenserAddress key on purpose. Before deploying, add it and set
+#   it to the CURRENT LIVE Dispenser address from the autonolas-tokenomics repo's
+#   globals_<network>.json. WHICH KEY holds that address depends on whether the proxied-Dispenser
+#   migration has happened yet:
+#     - BEFORE the migration (today): the live Dispenser is the plain `dispenserAddress` key.
+#     - AFTER the migration (once deploy_07b_dispenser_proxy.sh has run there): the live Dispenser
+#       is `dispenserProxyAddress`, and from that point `dispenserAddress` in that repo means the
+#       Dispenser IMPLEMENTATION behind the proxy — NEVER copy that one here.
+#   Whenever new Dispenser contracts are deployed there this value changes and MUST be re-copied
+#   before VoteWeighting is deployed: VoteWeighting binds the dispenser immutably, so a wrong or
+#   stale address can only be fixed by redeploying VoteWeighting.
+#   Cross-repo runbook (the same handoff from the tokenomics side, step 9):
+#   https://github.com/valory-xyz/autonolas-tokenomics/blob/main/docs/dispenser_migration_runbook_public.md
 #
 # Writes:  globals.voteWeightingAddress  (overwrites any previous VoteWeighting address)
 
@@ -80,10 +86,44 @@ dispenserAddress=$(jq -r '.dispenserAddress' $globals)
 if [ "$dispenserAddress" == "null" ] || [ -z "$dispenserAddress" ] || [ "$dispenserAddress" == "0x0000000000000000000000000000000000000000" ]; then
   echo "${red}!!! dispenserAddress is not set (or is the zero address) in $globals${reset}"
   echo "${red}    VoteWeighting binds the dispenser immutably; refusing to deploy with no dispenser.${reset}"
-  echo "${red}    Copy the current dispenserProxyAddress from the autonolas-tokenomics globals_$1.json${reset}"
-  echo "${red}    into dispenserAddress here, and re-check it after every new Dispenser deployment.${reset}"
+  echo "${red}    Copy the LIVE Dispenser address from the autonolas-tokenomics globals_$1.json into${reset}"
+  echo "${red}    dispenserAddress here: key 'dispenserAddress' before the proxied-Dispenser migration,${reset}"
+  echo "${red}    key 'dispenserProxyAddress' after it (then their 'dispenserAddress' is the${reset}"
+  echo "${red}    implementation — never copy that). Re-check after every new Dispenser deployment.${reset}"
   exit 1
 fi
+
+rpcURL="$networkURL$API_KEY"
+
+# Pre-flight on the dispenser BEFORE deploying: the post-deploy asserts below can only report a
+# wrong dispenser, they cannot undo it (immutable), so the cheap checks that can prevent the
+# mistake belong here.
+#   1. It must be a contract at all — an EOA / empty address would brick the link silently.
+#   2. owner() must be non-zero. This is what separates a live Dispenser from the Dispenser
+#      IMPLEMENTATION address: the implementation's constructor sets immutables only, its owner
+#      lives in initialize() which the DispenserProxy constructor delegatecalls — so a bare
+#      implementation reads owner() == 0, while both the pre-migration live Dispenser and the
+#      post-migration DispenserProxy read a real owner.
+# Note: voteWeighting() is NOT usable as a check here — a freshly deployed DispenserProxy is
+# initialized with voteWeighting == 0 by design (this contract does not exist yet and binds the
+# proxy), so it is printed for information only.
+dispenserCode=$(cast code --rpc-url $rpcURL $dispenserAddress)
+if [ "$dispenserCode" == "0x" ] || [ -z "$dispenserCode" ]; then
+  echo "${red}!!! dispenserAddress $dispenserAddress has no contract code on chain $chainId${reset}"
+  exit 1
+fi
+
+dispenserOwner=$(cast call --rpc-url $rpcURL $dispenserAddress "owner()(address)" 2>/dev/null)
+if [ -z "$dispenserOwner" ] || [ "$dispenserOwner" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! dispenserAddress $dispenserAddress reads owner() == 0 (or has no owner())${reset}"
+  echo "${red}    This looks like a Dispenser IMPLEMENTATION rather than the live Dispenser /${reset}"
+  echo "${red}    DispenserProxy. Binding it here is immutable and unrecoverable — refusing to deploy.${reset}"
+  exit 1
+fi
+
+dispenserVW=$(cast call --rpc-url $rpcURL $dispenserAddress "voteWeighting()(address)" 2>/dev/null)
+echo "${green}Pre-flight dispenser $dispenserAddress: owner() = $dispenserOwner${reset}"
+echo "  voteWeighting() = ${dispenserVW:-<no such getter>}  (zero is expected on a freshly deployed proxy)"
 
 contractName="VoteWeighting"
 contractPath="contracts/$contractName.sol:$contractName"
@@ -123,7 +163,6 @@ fi
 echo "$(jq '. += {"voteWeightingAddress":"'$voteWeightingAddress'"}' $globals)" > $globals
 
 # Post-deploy sanity: the immutable ve / dispenser slots must equal the constructor args
-rpcURL="$networkURL$API_KEY"
 veGetter=$(cast call --rpc-url $rpcURL $voteWeightingAddress "ve()(address)")
 dispenserGetter=$(cast call --rpc-url $rpcURL $voteWeightingAddress "dispenser()(address)")
 ownerGetter=$(cast call --rpc-url $rpcURL $voteWeightingAddress "owner()(address)")

--- a/scripts/deployment/verify_23_vote_weighting.js
+++ b/scripts/deployment/verify_23_vote_weighting.js
@@ -6,8 +6,9 @@ const parsedData = JSON.parse(dataFromJSON);
 // The dispenser is immutable and part of the constructor args, so verification must encode the
 // exact address the contract was deployed with. Mirror the deploy scripts and refuse a
 // missing/zero dispenser rather than silently encoding the zero address.
-// dispenserAddress here must be the same value used at deployment time, i.e. the
-// `dispenserProxyAddress` copied from the autonolas-tokenomics globals for this network.
+// dispenserAddress here must be the same value used at deployment time, i.e. the live Dispenser
+// copied from the autonolas-tokenomics globals for this network (their `dispenserAddress` before
+// the proxied-Dispenser migration, their `dispenserProxyAddress` after it).
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 if (!parsedData.dispenserAddress || parsedData.dispenserAddress === zeroAddress) {
     throw new Error("dispenserAddress is not set (or is the zero address) in " + globalsFile +

--- a/scripts/deployment/verify_23_vote_weighting.js
+++ b/scripts/deployment/verify_23_vote_weighting.js
@@ -6,6 +6,8 @@ const parsedData = JSON.parse(dataFromJSON);
 // The dispenser is immutable and part of the constructor args, so verification must encode the
 // exact address the contract was deployed with. Mirror the deploy scripts and refuse a
 // missing/zero dispenser rather than silently encoding the zero address.
+// dispenserAddress here must be the same value used at deployment time, i.e. the
+// `dispenserProxyAddress` copied from the autonolas-tokenomics globals for this network.
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 if (!parsedData.dispenserAddress || parsedData.dispenserAddress === zeroAddress) {
     throw new Error("dispenserAddress is not set (or is the zero address) in " + globalsFile +


### PR DESCRIPTION
## What

`VoteWeighting` binds the Dispenser as an **immutable** constructor argument, but nothing in this repo documented where that address comes from. `scripts/deployment/globals_mainnet.json` ships with `dispenserAddress` unset (`null`), so `./scripts/deployment/deploy_23_vote_weighting.sh mainnet` aborts on the guard with no pointer to the fix.

## Changes

- **`scripts/deployment/README.md`** — new "Deployment of VoteWeighting" section: get-into-deployable-state steps, required env keys, the deploy command, and the push-back steps. It states the prerequisite explicitly: `dispenserAddress` must be set from the [autonolas-tokenomics](https://github.com/valory-xyz/autonolas-tokenomics) `globals_<network>.json` key **`dispenserProxyAddress`** — the `DispenserProxy`, not the implementation — and re-checked whenever new Dispenser contracts are deployed there.
- **`deploy_23_vote_weighting.sh`** — the same rule as a header `PREREQUISITE` block; the missing/zero-dispenser error message now names the source key. Documents that the script overwrites the previous `voteWeightingAddress`.
- **`deploy_23_vote_weighting.js` / `verify_23_vote_weighting.js`** — matching comments so the Hardhat deploy path and the verification args carry the same source of truth.

## Notes

- A stale dispenser address is only fixable by redeploying VoteWeighting, which is why the refresh is documented as a per-run check rather than a one-off.
- The runbook states VoteWeighting is **Ethereum mainnet only** (it binds L1 veOLAS and the L1 Dispenser), against `globals_mainnet.json` / `chainId` 1 — not an L2.

## Scope

Docs and off-chain deployment scripts only. **No contract source is touched**, so no on-chain bytecode implications.

## Checks

`eslint` and `solhint` both clean (warnings only, all pre-existing). `bash -n` passes on the shell script.