### PR TITLE
docs: fix the entry 10 table-of-contents anchor

### DIFF
--- a/docs/Vulnerabilities_list_governance.md
+++ b/docs/Vulnerabilities_list_governance.md
@@ -13,7 +13,7 @@
 | 7 | [processMessageFromForeign function](#7-processmessagefromforeign-function) | Informative |
 | 8 | [removeNominee function](#8-removenominee-function) | Medium |
 | 9 | [_addNominee and removeNominee functions](#9-_addnominee-and-removenominee-functions) | Informative |
-| 10 | [voteForNomineeWeights function](#10-voteforNomineeweights-function) | Informative |
+| 10 | [voteForNomineeWeights function](#10-votefornomineeweights-function) | Informative |
 | 11 | [removeNominee OwnerOnly revert-data argument order](#11-removenominee-owneronly-revert-data-argument-order) | Informative |
 | 12 | [OLAS mint silent no-op on inflation cap](#12-olas-mint-silent-no-op-on-inflation-cap) | Informative |
 | 13 | [governorDelay and timelock minDelay desynchronization](#13-governordelay-and-timelock-mindelay-desynchronization) | Informative |


### PR DESCRIPTION
The table-of-contents row for entry 10 points at `#10-voteforNomineeweights-function` — note the capital `N` in the middle. Heading anchors are lowercased, so this resolves to nothing and the link is dead.

Pre-existing — unrelated to the entry added in #222. Found by a table-of-contents integrity check (numbering, duplicates, coverage, ordering, anchor resolution) run across all four vulnerability lists after that PR merged.