### PR TITLE
docs: record that the heartbeat proposal parameters are withheld deliberately

### DIFF
--- a/contracts/multisigs/GuardCM.sol
+++ b/contracts/multisigs/GuardCM.sol
@@ -110,7 +110,14 @@ contract GuardCM is VerifyData {
     bytes4 public constant SCHEDULE_BATCH = bytes4(keccak256(bytes("scheduleBatch(address[],uint256[],bytes[],bytes32,bytes32,uint256)")));
     // requireToPassMessage selector (Gnosis chain)
     // Initial check governance proposal Id
-    // Calculated from the proposalHash function of the GovernorOLAS
+    // Calculated from the proposalHash function of the GovernorOLAS.
+    // The proposal parameters behind this Id are intentionally NOT committed to this repository. The
+    // heartbeat proposal must only be creatable when the DAO chooses to create it: anyone able to create it
+    // could let it be defeated and thereby arm the multisig release path in pause() on their own schedule.
+    // state() reverting with "unknown proposal id" while no heartbeat is outstanding is therefore the
+    // expected resting state, not a fault.
+    // Older audit artifacts in this repository document a SUPERSEDED Id together with its parameters. Do
+    // not reconcile this value against them, and do not replace it with one whose parameters are public.
     uint256 public governorCheckProposalId = 88250008686885504216650933897987879122244685460173810624866685274624741477673;
     // Minimum data length that is encoded for the schedule function,
     // plus at least 4 bytes or 32 bits for the selector from the payload

--- a/test/GuardCM.js
+++ b/test/GuardCM.js
@@ -600,7 +600,9 @@ describe("Community Multisig Guard", function () {
             // Take a snapshot of the current state of the blockchain
             const snapshot = await helpers.takeSnapshot();
 
-            // Change the proposal Id to a known one
+            // Change the proposal Id to a known one. This is a superseded, publicly-documented heartbeat
+            // used so the test can create the proposal; the deployed default's parameters are withheld
+            // deliberately and this value must not be read as the one the deployment should carry.
             const payload = guard.interface.encodeFunctionData("changeGovernorCheckProposalId",
                 ["62151151991217526951504761219057817227643973118811130641152828658327965685127"]);
             await timelock.execute(guard.address, payload);


### PR DESCRIPTION
`governorCheckProposalId` carries nothing indicating that the parameters producing it are intentionally unpublished. Meanwhile an older flattened source under `audits/` still documents a **superseded** Id alongside its parameters, and `test/GuardCM.js` overwrites the deployed default with that older value before exercising the release path.

A reader comparing the documented tuple against the deployed constant finds a mismatch and concludes the community-multisig release is unarmable.

**That reading is wrong, and it has now been reached three separate times** — by an external reviewer, by our own later analysis, and by an internal audit note that asked whether the current value tracks a live heartbeat convention and was never actioned. Three independent readers making the same mistake is a documentation defect rather than three coincidences.

## What the comment says

- The parameters are withheld deliberately, so the heartbeat is creatable only when the DAO chooses — anyone able to create it could let it be defeated and thereby arm `pause()` on their own schedule.
- `state()` reverting with *unknown proposal id* while no heartbeat is outstanding is the **expected resting state**, not a fault.
- Do not reconcile this value against the superseded artifacts, and do not replace it with one whose parameters are public.

The test gains a matching note that the value it sets is the superseded, publicly-documented heartbeat, used so the test can create the proposal at all.

## No parameters are added

Nothing here narrows what the withheld parameters are — no wording, length or format. The only tuple referenced is the superseded one, which is already public in this repository and arms nothing.