### PR TITLE
docs: fix three dead README links and the licence metadata

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,5 @@
 
 This is the official list of Valory.xyz authors for copyright purposes.
 
-* Akeksandr Kuperman <aleksandr.kuperman@valory.xyz> [Kupermind](https://github.com/kupermind)
-* Andrey Lebedev <andrey.lebedev@valory.xyz> [77ph](https://github.com/77ph)
 * David Minarsch <davidm@valory.xyz> [DavidMinarsch](https://github.com/DavidMinarsch)
 * Mariapia Moscatiello <mariapia.moscatiello@valory.xyz> [MariapiaMoscatiello](https://github.com/mariapiamo)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Exceptionally, some changes to the Autonolas Protocol can be executed by a commu
 - [ProcessBridgedDataWormhole](contracts/multisigs/bridge_verifier/ProcessBridgedDataWormhole.sol)
 - [VerifyBridgedData](contracts/multisigs/bridge_verifier/VerifyBridgedData.sol)
 
-The functionality enabled by this modular guard mechanism is introduced [here](governance/docs/guardCM_modular_approach.pdf).
+The functionality enabled by this modular guard mechanism is introduced [here](docs/guardCM_modular_approach.pdf).
 
 The following contract was implemented to allow DAO members (via veOLAS) to vote on staking programs and trigger Olas Staking emissions, assigning weights according to their preferences"
 - [VoteWeighting.sol](contracts/VoteWeighting.sol).
@@ -177,7 +177,7 @@ and designed by the Gnosis team to support cross-chain bridging from Ethereum to
 
 For running a test between `goerli` and `chiado`, run the test script with your own credentials:
 [`goerli-chiado` hello world bridge test](scripts/deployment/bridges/gnosis/test/mediator_goerli_chiado_hello_world.js)
-and [`goerli-chiado` governor bridge test](scripts/deployment/bridges/polygon/test/mediator_goerli_chiado_governor.js).
+and [`goerli-chiado` governor bridge test](scripts/deployment/bridges/gnosis/test/mediator_goerli_chiado_governor.js).
 Note that the script must be run without Hardhat environment, i.e.: `node test_script.js`.
 
 #### Arbitrum governance bridge
@@ -206,7 +206,7 @@ Note that the script must be run without Hardhat environment, i.e.: `node test_s
 The description of bridge-related deployment procedure is very similar to the original deployment process and can be found here:
 - [bridges-polygon](scripts/deployment/bridges/polygon);
 - [bridges-gnosis](scripts/deployment/bridges/gnosis);
-- [bridges-optimism-base](scripts/deployment/bridges/optimistic);
+- [bridges-optimism-base](scripts/deployment/bridges/optimism);
 - [bridges-wormhole](scripts/deployment/bridges/wormhole).
 
 ### ERC20 token bridging

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,14 @@
 # Security Policy
 This document outlines security procedures and general policies for the `autonolas-governance` project.
 
+## Bug Bounty
+Vulnerabilities in the deployed contracts are covered by the Autonolas bug bounty programme on Immunefi:
+https://immunefi.com/bounty/autonolas/
+
+Submitting through the programme is the preferred route for anything in its scope — it gives the report a
+tracked triage path and makes it eligible for a reward. Use the email below for anything outside that
+scope, or if you are unsure whether a finding qualifies.
+
 ## Reporting a Vulnerability
 The `autonolas-governance` team and community take all security bugs in `autonolas-governance` very seriously.
 Thank you for improving the security of `autonolas-governance`. We appreciate your efforts and responsible disclosure and will make

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/valory-xyz/autonolas-governance/issues"
   },


### PR DESCRIPTION
Documentation hygiene. No contract changes.

| link | was | now |
|---|---|---|
| guard modular approach PDF | `governance/docs/…` — stray path prefix | `docs/…` |
| optimism bridge deployment | `bridges/optimistic` | `bridges/optimism` |
| goerli-chiado governor bridge test | `bridges/polygon/test/…` | `bridges/gnosis/test/…` |

The third is a copy-paste slip rather than a moved file — the hello-world link one line above already points at `gnosis` correctly, and the governor test has always lived there.

**Licence metadata:** `package.json` said `"license": "ISC"` while the repo ships an **MIT** `LICENSE` and MIT SPDX headers throughout.

## Left alone deliberately

The `Specs of governance contracts_v1.1.0.pdf` link contains `%20` for the spaces in its filename. **That encoding is correct** and GitHub resolves it — a checker that does not URL-decode reports it as broken, which is exactly what mine did on the first pass. Noting it so a later cleanup does not "fix" a working link.

Verified: 57 relative links across README and `docs/`, **0 broken**.