### PR TITLE
proposal 13: correct the PolySafe fallback wording and pin the whole JSON

### DIFF
--- a/scripts/proposals/proposal_13/README.md
+++ b/scripts/proposals/proposal_13/README.md
@@ -92,11 +92,28 @@ chunks** — an empty result and a refused result are indistinguishable otherwis
 
 </details>
 
-After execution, a service that would have deployed a PolySafe
-deploys an ordinary Safe instead. `GnosisSafeMultisig`
+**There is no on-chain fallback — the caller chooses.** `ServiceRegistryL2.deploy()` does not substitute
+another implementation when the supplied creator is disabled; it checks the bit and reverts:
+
+```solidity
+if (!mapMultisigs[multisigImplementation]) {
+    revert UnauthorizedMultisig(multisigImplementation);   // ServiceRegistryL2.sol:508-510
+}
+```
+
+So after execution a deployment request that still names the PolySafe creator **fails**; it does not
+silently become an ordinary Safe. `GnosisSafeMultisig`
 ([`0x3d77596b…`](https://polygonscan.com/address/0x3d77596beb0f130a4415df3D2D8232B3d3D31e44)) remains
-whitelisted and is the fallback; the Polygon fork test asserts it survives untouched. The change is
-reversible by re-whitelisting, but any in-flight PolySafe deployment reverts in the meantime.
+whitelisted and is the implementation clients should select instead — the Polygon fork test asserts its bit
+survives untouched, which is the same bit `deploy()` reads. Existing PolySafes are unaffected and keep
+operating; only the creation path closes. The change is reversible by re-whitelisting through the same
+tunnel path.
+
+**Why the residual tail is acceptable.** PolySafe is being deprecated across all clients concurrently with
+this proposal, so the expectation is zero callers by execution. The tail above is consistent with that:
+usage fell from 92 in April to 1 in the 30 days to 2026-09-01, the last creation being 2026-08-15. Anyone
+who has not migrated by execution gets a clear `UnauthorizedMultisig` revert rather than a silent
+substitution, and re-whitelisting is one governance action away.
 
 ## ⚠ Address collisions — read before editing any constant
 

--- a/test/proposals/Proposal13Housekeeping.t.sol
+++ b/test/proposals/Proposal13Housekeeping.t.sol
@@ -300,13 +300,32 @@ contract Proposal13HousekeepingTest is Test, Proposal13Builder {
 
     /// @dev The committed artifacts must match the builder, not merely each other. The builder header warns
     ///      that description.txt has to match byte-for-byte; this checks the file rather than trusting it.
+    ///
+    ///      calldata.json is the array a human copy-pastes into GovernorOLAS.propose(), and the README
+    ///      documents extracting it by hand, so EVERY field that reaches propose() is pinned here — count,
+    ///      index, target, value and calldata. Pinning only target and calldata leaves an accidental
+    ///      non-zero value or a fourth entry passing both Solidity tests while changing the proposal that
+    ///      actually executes, and its id.
     function test_committedArtifactsMatchTheBuilder() public view {
-        (address[] memory targets,, bytes[] memory calldatas, string memory description) = buildProposal();
+        (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) =
+            buildProposal();
 
         string memory onDisk = vm.readFile("scripts/proposals/proposal_13/description.txt");
         assertEq(keccak256(bytes(onDisk)), keccak256(bytes(description)), "description.txt has drifted from the builder");
 
         string memory json = vm.readFile("scripts/proposals/proposal_13/calldata.json");
+
+        // Entry count, by asserting the array ends exactly where the builder does. Without this an
+        // appended fourth entry is simply never looked at by the loop below.
+        assertTrue(
+            vm.keyExistsJson(json, string.concat("$[", vm.toString(targets.length - 1), "]")),
+            "calldata.json has fewer entries than the builder"
+        );
+        assertFalse(
+            vm.keyExistsJson(json, string.concat("$[", vm.toString(targets.length), "]")),
+            "calldata.json has more entries than the builder"
+        );
+
         for (uint256 i; i < targets.length; ++i) {
             string memory ix = vm.toString(i);
             assertEq(
@@ -316,6 +335,16 @@ contract Proposal13HousekeepingTest is Test, Proposal13Builder {
             assertEq(
                 vm.parseJsonAddress(json, string.concat("$[", ix, "].target")), targets[i],
                 string.concat("calldata.json target ", ix, " has drifted from the builder")
+            );
+            // value is written as a JSON string, so compare it as one rather than coercing.
+            assertEq(
+                vm.parseJsonString(json, string.concat("$[", ix, "].value")), vm.toString(values[i]),
+                string.concat("calldata.json value ", ix, " has drifted from the builder")
+            );
+            // index is what tells the operator which row goes where; a wrong one reorders the proposal.
+            assertEq(
+                vm.parseJsonUint(json, string.concat("$[", ix, "].index")), i,
+                string.concat("calldata.json index ", ix, " is not in builder order")
             );
         }
     }


### PR DESCRIPTION
Two follow-ups from an external review of proposal 13. **No proposal input changes** — `calldata.json`, `description.txt` and the builder are untouched, so the pinned `proposalId` and `descriptionHash` cannot have moved. 10/10 tests pass against live Ethereum, Mode and Polygon.

## 1. The README described behaviour the registry does not have

It said *"a service that would have deployed a PolySafe deploys an ordinary Safe instead."* `ServiceRegistryL2.deploy()` performs no substitution — I checked the source rather than the claim:

```solidity
if (!mapMultisigs[multisigImplementation]) {
    revert UnauthorizedMultisig(multisigImplementation);   // ServiceRegistryL2.sol:508-510
}
```

A request still naming the PolySafe creator **fails**; the caller must select `GnosisSafeMultisig` itself. Voters read this file to decide, so "silently substituted" vs "reverts" is not a wording preference.

The section now also states what is *not* affected — existing PolySafes keep operating, only the creation path closes — and that the change is reversible through the same tunnel path.

**The residual tail is recorded as accepted rather than left open.** PolySafe is being deprecated across all clients concurrently with this proposal. The numbers support that reading:

| period | creations |
|---|---|
| April 2026 | 92 |
| 30 days to 2026-09-01 | **1** |

Last creation 2026-08-15. I re-derived all 259 `MultisigCreated` events independently and the count matches the README's. Anyone who has not migrated by execution gets an explicit `UnauthorizedMultisig` revert rather than a silent substitution.

## 2. The artifact test pinned two fields out of five

`calldata.json` is the array a human copy-pastes into `GovernorOLAS.propose()`, and the README documents extracting it **by hand**. The test compared only `target` and `calldata` — so an accidental non-zero `value`, a reordered `index`, or an appended fourth entry passed both Solidity tests while changing the proposal that actually executes, and its id.

Count, `index` and `value` are now pinned too. Count is asserted from **both ends** — `$[n-1]` exists, `$[n]` does not — because a loop bounded by the builder's length never looks at an appended entry.

### Controls

A passing test proves nothing on its own, so I mutated `calldata.json` four ways:

| mutation | result |
|---|---|
| `value` 0 → 1 on entry 1 | `FAIL: calldata.json value 1 has drifted from the builder: 1 != 0` |
| appended a fourth entry | `FAIL: calldata.json has more entries than the builder` |
| `index` 2 → 5 | `FAIL: calldata.json index 2 is not in builder order: 5 != 2` |
| removed an entry | `FAIL: calldata.json has fewer entries than the builder` |

File restored, `PASS`, working tree clean.

## Deliberately not done

- **End-to-end deployment test with the replacement creator.** `deploy()` gates on exactly the `mapMultisigs` bit the Polygon fork test already asserts survives. It would re-prove the same bit through more machinery.
- **CI regeneration and byte-comparison of `proposal_13.html`.** It is an annotated view, never executed, and was independently verified byte-identical. A CI job for a one-off artifact will rot.
